### PR TITLE
Add statistic bars to Pokémon cards

### DIFF
--- a/src/app/team/data/pokemon.mapper.ts
+++ b/src/app/team/data/pokemon.mapper.ts
@@ -2,6 +2,15 @@ import { Injectable } from '@angular/core';
 import { PokemonDTO } from '../models/pokeapi.dto';
 import { PokemonVM } from '../models/view.model';
 
+const STAT_LABELS: Record<string, string> = {
+  hp: 'Vida',
+  attack: 'Ataque',
+  defense: 'Defensa',
+  'special-attack': 'Ataque especial',
+  'special-defense': 'Defensa especial',
+  speed: 'Velocidad',
+};
+
 @Injectable({ providedIn: 'root' })
 export class PokemonMapper {
   toVM(dto: PokemonDTO): PokemonVM {
@@ -13,6 +22,15 @@ export class PokemonMapper {
       typeDetails: dto.types
         .sort((a, b) => a.slot - b.slot)
         .map((t) => ({ name: t.type.name, url: t.type.url })),
+      stats: dto.stats?.map((stat) => ({
+        name: stat.stat.name,
+        label: STAT_LABELS[stat.stat.name] ?? this.toTitleCase(stat.stat.name.replace(/-/g, ' ')),
+        value: stat.base_stat,
+      })) ?? [],
     };
+  }
+
+  private toTitleCase(value: string): string {
+    return value.replace(/\w\S*/g, (txt) => txt[0].toUpperCase() + txt.substring(1).toLowerCase());
   }
 }

--- a/src/app/team/models/pokeapi.dto.ts
+++ b/src/app/team/models/pokeapi.dto.ts
@@ -3,6 +3,7 @@ export interface PokemonDTO {
   name: string;
   sprites: { front_default: string | null };
   types: { slot: number; type: { name: string; url: string } }[];
+  stats: { base_stat: number; stat: { name: string } }[];
 }
 
 export interface PokemonNameItem {

--- a/src/app/team/models/view.model.ts
+++ b/src/app/team/models/view.model.ts
@@ -1,7 +1,14 @@
+export interface PokemonStatVM {
+  name: string;
+  label: string;
+  value: number;
+}
+
 export interface PokemonVM {
   id: number;
   name: string;
   sprite: string | null;
   types: string[];
   typeDetails: { name: string; url: string }[];
+  stats: PokemonStatVM[];
 }

--- a/src/app/team/ui/pokemon/pokemon.component.html
+++ b/src/app/team/ui/pokemon/pokemon.component.html
@@ -23,6 +23,26 @@
     </div>
   </header>
 
+  @if (pokemon.stats.length) {
+  <section class="stats">
+    <h4 class="stats__title">Estadísticas</h4>
+    <ul class="stats__list">
+      @for (stat of pokemon.stats; track stat.name) {
+      <li class="stats__item">
+        <span class="stats__label">{{ stat.label }}</span>
+        <div class="stats__bar">
+          <div
+            class="stats__bar-fill"
+            [style.width.%]="getStatPercentage(stat.value)"
+          ></div>
+        </div>
+        <span class="stats__value">{{ stat.value }}</span>
+      </li>
+      }
+    </ul>
+  </section>
+  }
+
   <footer class="actions">
     @if (showRemove) {
     <button type="button" class="btn-remove" (click)="onRemove()">Quitar</button>

--- a/src/app/team/ui/pokemon/pokemon.component.scss
+++ b/src/app/team/ui/pokemon/pokemon.component.scss
@@ -58,6 +58,66 @@
   }
 }
 
+.stats {
+  display: flex;
+  flex-direction: column;
+  gap: .5rem;
+
+  &__title {
+    margin: 0;
+    font-size: .875rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: .05em;
+    color: #4b5563;
+  }
+
+  &__list {
+    display: flex;
+    flex-direction: column;
+    gap: .5rem;
+    margin: 0;
+    padding: 0;
+    list-style: none;
+  }
+
+  &__item {
+    display: flex;
+    align-items: center;
+    gap: .5rem;
+    font-size: .875rem;
+    color: #111827;
+  }
+
+  &__label {
+    flex: 0 0 120px;
+    text-transform: capitalize;
+  }
+
+  &__bar {
+    position: relative;
+    flex: 1;
+    height: .5rem;
+    background: #e5e7eb;
+    border-radius: 9999px;
+    overflow: hidden;
+  }
+
+  &__bar-fill {
+    height: 100%;
+    background: linear-gradient(90deg, #60a5fa 0%, #2563eb 100%);
+    border-radius: inherit;
+    transition: width .3s ease;
+  }
+
+  &__value {
+    flex: 0 0 2.5rem;
+    text-align: right;
+    font-variant-numeric: tabular-nums;
+    font-weight: 600;
+  }
+}
+
 /* Footer pegado abajo para acciones consistentes */
 .actions {
   margin-top: auto;        /* empuja el footer al fondo */

--- a/src/app/team/ui/pokemon/pokemon.component.ts
+++ b/src/app/team/ui/pokemon/pokemon.component.ts
@@ -11,7 +11,20 @@ import { TypeIcon } from '../../../shared/ui/type-icon/type-icon';
   styleUrl: './pokemon.component.scss',
 })
 export class PokemonComponent {
-  @Input() pokemon!: PokemonVM;
+  private _pokemon!: PokemonVM;
+  private maxStatValue = 0;
+
+  @Input() set pokemon(value: PokemonVM) {
+    this._pokemon = {
+      ...value,
+      stats: value.stats ?? [],
+    };
+    this.maxStatValue = this._pokemon.stats.reduce((max, stat) => Math.max(max, stat.value), 0);
+  }
+  get pokemon(): PokemonVM {
+    return this._pokemon;
+  }
+
   @Input() showRemove = true; // por si quieres ocultar el botón en otros contextos
   @Output() remove = new EventEmitter<number>();
 
@@ -21,10 +34,18 @@ export class PokemonComponent {
     this.remove.emit(this.pokemon.id);
   }
 
-
   trackType(i: number, t: any) { return t?.name ?? i; }
 
   icon$(url: string) {
     return this.typeIcons.getIconByTypeUrl(url);
+  }
+
+  getStatPercentage(statValue: number): number {
+    if (!this.maxStatValue) {
+      return 0;
+    }
+
+    const percentage = (statValue / this.maxStatValue) * 100;
+    return Math.min(100, Math.round(percentage));
   }
 }


### PR DESCRIPTION
## Summary
- include base stat information in the Pokémon view model with localized labels
- render a statistics section in the Pokémon card with proportional progress bars
- style the new stats list and compute bar widths relative to each Pokémon

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dba87653648326ab7313793fe179fa