### PR TITLE
Use stat-specific maximums for Pokemon stat bars

### DIFF
--- a/src/app/team/ui/pokemon/pokemon.component.html
+++ b/src/app/team/ui/pokemon/pokemon.component.html
@@ -33,7 +33,7 @@
         <div class="stats__bar">
           <div
             class="stats__bar-fill"
-            [style.width.%]="getStatPercentage(stat.value)"
+            [style.width.%]="getStatPercentage(stat)"
           ></div>
         </div>
         <span class="stats__value">{{ stat.value }}</span>

--- a/src/app/team/ui/pokemon/pokemon.component.ts
+++ b/src/app/team/ui/pokemon/pokemon.component.ts
@@ -1,6 +1,6 @@
 import { CommonModule } from '@angular/common';
 import { Component, EventEmitter, inject, Input, Output } from '@angular/core';
-import { PokemonVM } from '../../models/view.model';
+import { PokemonStatVM, PokemonVM } from '../../models/view.model';
 import { TypeIconService } from '../../data/type-icon.service';
 import { TypeIcon } from '../../../shared/ui/type-icon/type-icon';
 
@@ -12,14 +12,20 @@ import { TypeIcon } from '../../../shared/ui/type-icon/type-icon';
 })
 export class PokemonComponent {
   private _pokemon!: PokemonVM;
-  private maxStatValue = 0;
+  private static readonly STAT_MAX_VALUES: Record<string, number> = {
+    hp: 255,
+    attack: 190,
+    defense: 250,
+    'special-attack': 194,
+    'special-defense': 250,
+    speed: 200,
+  };
 
   @Input() set pokemon(value: PokemonVM) {
     this._pokemon = {
       ...value,
       stats: value.stats ?? [],
     };
-    this.maxStatValue = this._pokemon.stats.reduce((max, stat) => Math.max(max, stat.value), 0);
   }
   get pokemon(): PokemonVM {
     return this._pokemon;
@@ -40,12 +46,14 @@ export class PokemonComponent {
     return this.typeIcons.getIconByTypeUrl(url);
   }
 
-  getStatPercentage(statValue: number): number {
-    if (!this.maxStatValue) {
+  getStatPercentage(stat: PokemonStatVM): number {
+    const maxStatValue = PokemonComponent.STAT_MAX_VALUES[stat.name] ?? 0;
+
+    if (!maxStatValue) {
       return 0;
     }
 
-    const percentage = (statValue / this.maxStatValue) * 100;
+    const percentage = (stat.value / maxStatValue) * 100;
     return Math.min(100, Math.round(percentage));
   }
 }


### PR DESCRIPTION
## Summary
- calculate stat bar percentages against predefined maxima for each stat type
- update the pokemon stat template to provide the full stat to the percentage helper

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dbb0c026788326b0be482b1d0c5ba5