### PR TITLE
Add dynamic color scaling to Pokémon stat bars

### DIFF
--- a/src/app/team/ui/pokemon/pokemon.component.html
+++ b/src/app/team/ui/pokemon/pokemon.component.html
@@ -34,6 +34,7 @@
           <div
             class="stats__bar-fill"
             [style.width.%]="getStatPercentage(stat)"
+            [style.background]="getStatGradient(stat)"
           ></div>
         </div>
         <span class="stats__value">{{ stat.value }}</span>

--- a/src/app/team/ui/pokemon/pokemon.component.ts
+++ b/src/app/team/ui/pokemon/pokemon.component.ts
@@ -56,4 +56,13 @@ export class PokemonComponent {
     const percentage = (stat.value / maxStatValue) * 100;
     return Math.min(100, Math.round(percentage));
   }
+
+  getStatGradient(stat: PokemonStatVM): string {
+    const percentage = this.getStatPercentage(stat);
+    const hue = Math.round((percentage / 100) * 240);
+    const startColor = `hsl(${hue}, 85%, 55%)`;
+    const endColor = `hsl(${hue}, 85%, 45%)`;
+
+    return `linear-gradient(90deg, ${startColor} 0%, ${endColor} 100%)`;
+  }
 }


### PR DESCRIPTION
## Summary
- compute a hue-based gradient for each Pokémon stat according to its percentage of the max value
- bind the stat bar background to the dynamic gradient so colors shift from red through blue as values increase

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dbb9a1c95c8326b85366450aab73fa