### PR TITLE
feat: persist team in firebase

### DIFF
--- a/src/app/shared/firebase/firebase.config.ts
+++ b/src/app/shared/firebase/firebase.config.ts
@@ -1,0 +1,15 @@
+import { initializeApp } from 'firebase/app';
+import { getFirestore } from 'firebase/firestore';
+
+const firebaseConfig = {
+  apiKey: 'AIzaSyApUdIt3-5WG8lBz1D6gLDa-VgeCFXjtMQ',
+  authDomain: 'poketeam-c9c09.firebaseapp.com',
+  projectId: 'poketeam-c9c09',
+  storageBucket: 'poketeam-c9c09.firebasestorage.app',
+  messagingSenderId: '502399047563',
+  appId: '1:502399047563:web:2e326ce897865e5680818e',
+  measurementId: 'G-KQ20ZXTB7E',
+};
+
+export const firebaseApp = initializeApp(firebaseConfig);
+export const firestore = getFirestore(firebaseApp);

--- a/src/app/team/data/team.facade.ts
+++ b/src/app/team/data/team.facade.ts
@@ -4,16 +4,18 @@ import { PokemonMapper } from './pokemon.mapper';
 import { PokemonVM } from '../models/view.model';
 import { toObservable } from '@angular/core/rxjs-interop';
 import { debounceTime, distinctUntilChanged, filter, forkJoin, map, of, switchMap, take, tap } from 'rxjs';
-import { storage } from '../../shared/util/storage.util';
 import { PokemonDTO } from '../models/pokeapi.dto';
+import { TeamRepository } from './team.repository';
 
-const TEAM_KEY = 'poketeams.team';
 const MAX_TEAM = 6;
 
 @Injectable({ providedIn: 'root' })
 export class TeamFacade {
   private api = inject(PokemonApi);
   private mapper = inject(PokemonMapper);
+  private repository = inject(TeamRepository);
+  private readonly teamLoaded = signal(false);
+  private readonly lastSynced = signal<string | null>(null);
 
   // --- Search state ---
   readonly query: WritableSignal<string> = signal('');
@@ -31,7 +33,7 @@ export class TeamFacade {
   readonly error = signal<string | null>(null);
 
   // --- Team state ---
-  readonly team = signal<PokemonVM[]>(storage.get<PokemonVM[]>(TEAM_KEY, []));
+  readonly team = signal<PokemonVM[]>([]);
   readonly canAdd = computed(() => this.team().length < MAX_TEAM);
 
   constructor() {
@@ -44,9 +46,31 @@ export class TeamFacade {
         error: () => this.error.set('No se pudo cargar la lista de Pokémon'),
       });
 
-    // Persist team
+    // Load team from Firebase once
+    this.repository
+      .loadTeam()
+      .then((members) => {
+        this.team.set(Array.isArray(members) ? members : []);
+        this.lastSynced.set(JSON.stringify(this.team()));
+      })
+      .catch((error) => {
+        console.error(error);
+        this.lastSynced.set(JSON.stringify(this.team()));
+      })
+      .finally(() => {
+        this.teamLoaded.set(true);
+      });
+
+    // Persist team updates to Firebase
     effect(() => {
-      storage.set(TEAM_KEY, this.team());
+      if (!this.teamLoaded()) return;
+      const current = this.team();
+      const serialized = JSON.stringify(current);
+      if (this.lastSynced() === serialized) return;
+      void this.repository
+        .saveTeam(current)
+        .then(() => this.lastSynced.set(serialized))
+        .catch((error) => console.error(error));
     });
 
     // Reactive search using signals→observable

--- a/src/app/team/data/team.repository.ts
+++ b/src/app/team/data/team.repository.ts
@@ -1,0 +1,39 @@
+import { Injectable } from '@angular/core';
+import { doc, getDoc, setDoc } from 'firebase/firestore';
+import { firestore } from '../../shared/firebase/firebase.config';
+import { PokemonVM } from '../models/view.model';
+
+interface TeamDocument {
+  members?: PokemonVM[];
+}
+
+const TEAM_COLLECTION = 'teams';
+const TEAM_DOCUMENT_ID = 'default';
+
+@Injectable({ providedIn: 'root' })
+export class TeamRepository {
+  private readonly docRef = doc(firestore, TEAM_COLLECTION, TEAM_DOCUMENT_ID);
+
+  async loadTeam(): Promise<PokemonVM[]> {
+    try {
+      const snapshot = await getDoc(this.docRef);
+      if (!snapshot.exists()) {
+        return [];
+      }
+      const data = snapshot.data() as TeamDocument | undefined;
+      return Array.isArray(data?.members) ? data!.members : [];
+    } catch (error) {
+      console.error('Error loading team from Firebase', error);
+      throw error;
+    }
+  }
+
+  async saveTeam(team: PokemonVM[]): Promise<void> {
+    try {
+      await setDoc(this.docRef, { members: team });
+    } catch (error) {
+      console.error('Error saving team to Firebase', error);
+      throw error;
+    }
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,26 +5,16 @@ import { routes } from './app/app.routes';
 import { App } from './app/app';
 
 // Import the functions you need from the SDKs you need
-import { initializeApp } from 'firebase/app';
-import { getAnalytics } from 'firebase/analytics';
-// TODO: Add SDKs for Firebase products that you want to use
-// https://firebase.google.com/docs/web/setup#available-libraries
+import { getAnalytics, isSupported } from 'firebase/analytics';
+import { firebaseApp } from './app/shared/firebase/firebase.config';
 
-// Your web app's Firebase configuration
-// For Firebase JS SDK v7.20.0 and later, measurementId is optional
-const firebaseConfig = {
-  apiKey: 'AIzaSyApUdIt3-5WG8lBz1D6gLDa-VgeCFXjtMQ',
-  authDomain: 'poketeam-c9c09.firebaseapp.com',
-  projectId: 'poketeam-c9c09',
-  storageBucket: 'poketeam-c9c09.firebasestorage.app',
-  messagingSenderId: '502399047563',
-  appId: '1:502399047563:web:2e326ce897865e5680818e',
-  measurementId: 'G-KQ20ZXTB7E',
-};
-
-// Initialize Firebase
-const app = initializeApp(firebaseConfig);
-const analytics = getAnalytics(app);
+if (typeof window !== 'undefined') {
+  void isSupported().then((supported: boolean) => {
+    if (supported) {
+      getAnalytics(firebaseApp);
+    }
+  });
+}
 
 bootstrapApplication(App, {
   providers: [provideHttpClient(withInterceptorsFromDi()), provideRouter(routes)],


### PR DESCRIPTION
## Summary
- add a shared Firebase configuration and Firestore-backed repository
- update the team facade to load and persist the roster with Firestore instead of localStorage
- initialize Firebase once at bootstrap and guard analytics initialization

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dbccbaa1b08326b64bf641bff8b661