### PR TITLE
feat: support multiple saved Pokémon teams

### DIFF
--- a/src/app/team/models/team.model.ts
+++ b/src/app/team/models/team.model.ts
@@ -1,0 +1,7 @@
+import { PokemonVM } from './view.model';
+
+export interface SavedTeam {
+  id: string;
+  name: string;
+  members: PokemonVM[];
+}

--- a/src/app/team/pages/team.page.html
+++ b/src/app/team/pages/team.page.html
@@ -17,6 +17,16 @@
         }
     </section>
     <aside>
-        <app-team-panel [team]="facade.team()" (remove)="facade.removeFromTeam($event)" (clear)="facade.clearTeam()" />
+        <app-team-panel
+            [team]="facade.team()"
+            [teamName]="facade.teamName()"
+            [savedTeams]="facade.savedTeams()"
+            [selectedTeamId]="facade.selectedTeamId()"
+            (teamNameChange)="facade.setTeamName($event)"
+            (selectTeam)="facade.selectTeam($event)"
+            (createTeam)="facade.createCurrentTeam()"
+            (remove)="facade.removeFromTeam($event)"
+            (clear)="facade.clearTeam()"
+        />
     </aside>
 </div>

--- a/src/app/team/ui/team-panel/team-panel.component.html
+++ b/src/app/team/ui/team-panel/team-panel.component.html
@@ -4,6 +4,29 @@
     <button class="btn-clear" type="button" (click)="clear.emit()" [disabled]="!team.length">Limpiar</button>
   </div>
 
+  <div class="team-controls">
+    <label class="control">
+      <span>Equipo guardado</span>
+      <select [ngModel]="selectedTeamId ?? 'new'" (ngModelChange)="onSelectChange($event)">
+        <option value="new">➕ Nuevo equipo</option>
+        @for (saved of savedTeams; track trackTeamId($index, saved)) {
+          <option [value]="saved.id">{{ saved.name }}</option>
+        }
+      </select>
+    </label>
+
+    <label class="control">
+      <span>Nombre del equipo</span>
+      <input type="text" [ngModel]="teamName" (ngModelChange)="teamNameChange.emit($event)" placeholder="Ingresa un nombre" />
+    </label>
+
+    @if (selectedTeamId === null) {
+      <button class="btn-save" type="button" (click)="createTeam.emit()" [disabled]="!teamName.trim()">Guardar nuevo equipo</button>
+    } @else {
+      <p class="muted autosave-note">Los cambios se guardan automáticamente.</p>
+    }
+  </div>
+
   @if (team.length) {
     <div class="team-grid">
       @for (p of team; track trackById($index, p)) {

--- a/src/app/team/ui/team-panel/team-panel.component.scss
+++ b/src/app/team/ui/team-panel/team-panel.component.scss
@@ -3,6 +3,59 @@
   gap: .75rem;
 }
 
+.team-controls {
+  display: grid;
+  gap: .5rem;
+  padding: .75rem;
+  background: #f9fafb;
+  border-radius: .75rem;
+  border: 1px solid #e5e7eb;
+}
+
+.control {
+  display: grid;
+  gap: .25rem;
+  font-size: .85rem;
+
+  span {
+    color: #4b5563;
+    font-weight: 600;
+  }
+
+  select,
+  input {
+    appearance: none;
+    border: 1px solid #d1d5db;
+    border-radius: .5rem;
+    padding: .45rem .6rem;
+    font-size: .95rem;
+    background: #fff;
+  }
+}
+
+.btn-save {
+  justify-self: start;
+  appearance: none;
+  border: 0;
+  background: #2563eb;
+  color: #fff;
+  font-weight: 600;
+  padding: .45rem .9rem;
+  border-radius: .5rem;
+  cursor: pointer;
+
+  &:hover { background: #1d4ed8; }
+  &:disabled {
+    opacity: .6;
+    cursor: default;
+  }
+}
+
+.autosave-note {
+  margin: 0;
+  font-size: .8rem;
+}
+
 .team-header {
   display: flex;
   align-items: center;

--- a/src/app/team/ui/team-panel/team-panel.component.ts
+++ b/src/app/team/ui/team-panel/team-panel.component.ts
@@ -1,20 +1,36 @@
 import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { FormsModule } from '@angular/forms';
 import { PokemonVM } from '../../models/view.model';
+import { SavedTeam } from '../../models/team.model';
 import { PokemonComponent } from '../pokemon/pokemon.component';
 
 @Component({
   standalone: true,
   selector: 'app-team-panel',
-  imports: [PokemonComponent],
+  imports: [FormsModule, PokemonComponent],
   styleUrls: ['./team-panel.component.scss'],
   templateUrl: './team-panel.component.html',
 })
 export class TeamPanelComponent {
   @Input({ required: true }) team: PokemonVM[] = [];
+  @Input({ required: true }) teamName = '';
+  @Input({ required: true }) savedTeams: SavedTeam[] = [];
+  @Input({ required: true }) selectedTeamId: string | null = null;
   @Output() remove = new EventEmitter<number>();
   @Output() clear = new EventEmitter<void>();
+  @Output() teamNameChange = new EventEmitter<string>();
+  @Output() selectTeam = new EventEmitter<string | null>();
+  @Output() createTeam = new EventEmitter<void>();
 
   trackById(_i: number, p: PokemonVM) {
     return (p as any).id ?? p;
+  }
+
+  trackTeamId(_i: number, team: SavedTeam) {
+    return team.id;
+  }
+
+  onSelectChange(value: string) {
+    this.selectTeam.emit(value === 'new' ? null : value);
   }
 }


### PR DESCRIPTION
## Summary
- extend the team repository to load, create, and update named team documents in Firestore
- add facade state for saved teams, team names, and selection with auto-sync and draft handling
- update the team panel UI to manage team names, choose saved teams, and create new teams with refreshed styles

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dc3dd3567883269240d929b22ef94a