### PR TITLE
Add move selection controls for team Pokémon

### DIFF
--- a/src/app/team/data/pokemon.api.ts
+++ b/src/app/team/data/pokemon.api.ts
@@ -1,7 +1,7 @@
 import { Injectable, inject } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable, map } from 'rxjs';
-import { PokemonDTO, PokemonListResponse } from '../models/pokeapi.dto';
+import { MoveDTO, PokemonDTO, PokemonListResponse } from '../models/pokeapi.dto';
 
 const API = 'https://pokeapi.co/api/v2';
 
@@ -18,5 +18,9 @@ export class PokemonApi {
 
   getPokemonByName(name: string): Observable<PokemonDTO> {
     return this.http.get<PokemonDTO>(`${API}/pokemon/${name.toLowerCase()}`);
+  }
+
+  getMoveByUrl(url: string): Observable<MoveDTO> {
+    return this.http.get<MoveDTO>(url);
   }
 }

--- a/src/app/team/models/pokeapi.dto.ts
+++ b/src/app/team/models/pokeapi.dto.ts
@@ -4,6 +4,7 @@ export interface PokemonDTO {
   sprites: { front_default: string | null };
   types: { slot: number; type: { name: string; url: string } }[];
   stats: { base_stat: number; stat: { name: string } }[];
+  moves: { move: { name: string; url: string } }[];
 }
 
 export interface PokemonNameItem {
@@ -13,4 +14,11 @@ export interface PokemonNameItem {
 export interface PokemonListResponse {
   count: number;
   results: PokemonNameItem[];
+}
+
+export interface MoveDTO {
+  id: number;
+  name: string;
+  power: number | null;
+  type: { name: string; url: string } | null;
 }

--- a/src/app/team/models/view.model.ts
+++ b/src/app/team/models/view.model.ts
@@ -11,4 +11,25 @@ export interface PokemonVM {
   types: string[];
   typeDetails: { name: string; url: string }[];
   stats: PokemonStatVM[];
+  moves: PokemonMoveOptionVM[];
+  selectedMoves: (PokemonMoveDetailVM | null)[];
+}
+
+export interface PokemonMoveOptionVM {
+  name: string;
+  label: string;
+  url: string;
+}
+
+export interface PokemonMoveDetailVM {
+  name: string;
+  url: string;
+  type: { name: string; url: string } | null;
+  power: number | null;
+}
+
+export interface PokemonMoveSelectionPayload {
+  pokemonId: number;
+  slot: number;
+  moveUrl: string | null;
 }

--- a/src/app/team/pages/team.page.html
+++ b/src/app/team/pages/team.page.html
@@ -27,6 +27,7 @@
             (createTeam)="facade.createCurrentTeam()"
             (remove)="facade.removeFromTeam($event)"
             (clear)="facade.clearTeam()"
+            (moveChange)="facade.changePokemonMove($event)"
         />
     </aside>
 </div>

--- a/src/app/team/ui/pokemon/pokemon.component.html
+++ b/src/app/team/ui/pokemon/pokemon.component.html
@@ -44,6 +44,42 @@
   </section>
   }
 
+  @if (pokemon.moves.length) {
+  <section class="moves">
+    <h4 class="moves__title">Movimientos</h4>
+    <ul class="moves__list">
+      @for (slot of moveSlots; track slot) {
+      @let selected = pokemon.selectedMoves[slot];
+      <li class="moves__item">
+        <label class="moves__label" [attr.for]="'move-' + pokemon.id + '-' + slot">
+          Movimiento {{ slot + 1 }}
+        </label>
+        <select
+          class="moves__select"
+          [id]="'move-' + pokemon.id + '-' + slot"
+          [ngModel]="selected?.url ?? ''"
+          (ngModelChange)="onMoveSelect(slot, $event)"
+        >
+          <option value="">Selecciona un movimiento</option>
+          @for (move of pokemon.moves; track trackMove($index, move)) {
+          <option [value]="move.url">{{ move.label }}</option>
+          }
+        </select>
+        @if (selected) {
+        <div class="moves__summary">
+          <span class="moves__name">{{ selected.name }}</span>
+          @if (selected.type) {
+          <app-type-icon class="moves__type" [typeDetails]="[selected.type]" [size]="18"></app-type-icon>
+          }
+          <span class="moves__power">Poder: {{ selected.power ?? '—' }}</span>
+        </div>
+        }
+      </li>
+      }
+    </ul>
+  </section>
+  }
+
   <footer class="actions">
     @if (showRemove) {
     <button type="button" class="btn-remove" (click)="onRemove()">Quitar</button>

--- a/src/app/team/ui/pokemon/pokemon.component.scss
+++ b/src/app/team/ui/pokemon/pokemon.component.scss
@@ -118,6 +118,84 @@
   }
 }
 
+.moves {
+  display: flex;
+  flex-direction: column;
+  gap: .5rem;
+
+  &__title {
+    margin: 0;
+    font-size: .875rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: .05em;
+    color: #4b5563;
+  }
+
+  &__list {
+    display: flex;
+    flex-direction: column;
+    gap: .75rem;
+    margin: 0;
+    padding: 0;
+    list-style: none;
+  }
+
+  &__item {
+    display: flex;
+    flex-direction: column;
+    gap: .35rem;
+  }
+
+  &__label {
+    font-size: .85rem;
+    font-weight: 500;
+    color: #111827;
+  }
+
+  &__select {
+    appearance: none;
+    padding: .4rem .5rem;
+    border: 1px solid #d1d5db;
+    border-radius: .5rem;
+    background: #f9fafb;
+    font-size: .9rem;
+    color: #111827;
+    transition: border-color .2s ease, box-shadow .2s ease;
+
+    &:focus {
+      outline: none;
+      border-color: #6366f1;
+      box-shadow: 0 0 0 3px rgba(99, 102, 241, .15);
+      background: #fff;
+    }
+  }
+
+  &__summary {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: .5rem;
+    font-size: .85rem;
+    color: #374151;
+  }
+
+  &__name {
+    font-weight: 600;
+    text-transform: capitalize;
+  }
+
+  &__type {
+    display: flex;
+    align-items: center;
+  }
+
+  &__power {
+    font-variant-numeric: tabular-nums;
+    color: #1f2937;
+  }
+}
+
 /* Footer pegado abajo para acciones consistentes */
 .actions {
   margin-top: auto;        /* empuja el footer al fondo */

--- a/src/app/team/ui/pokemon/pokemon.component.ts
+++ b/src/app/team/ui/pokemon/pokemon.component.ts
@@ -1,23 +1,34 @@
 import { CommonModule } from '@angular/common';
-import { Component, EventEmitter, inject, Input, Output } from '@angular/core';
+import { Component, EventEmitter, Input, Output, inject } from '@angular/core';
+import { FormsModule } from '@angular/forms';
 import { TypeIcon } from '../../../shared/ui/type-icon/type-icon';
 import { STAT_MAX_VALUES } from '../../../shared/util/constants';
 import { TypeIconService } from '../../data/type-icon.service';
-import { PokemonStatVM, PokemonVM } from '../../models/view.model';
+import {
+  PokemonMoveOptionVM,
+  PokemonMoveSelectionPayload,
+  PokemonStatVM,
+  PokemonVM,
+} from '../../models/view.model';
 
 @Component({
   selector: 'app-pokemon',
-  imports: [CommonModule, TypeIcon],
+  imports: [CommonModule, FormsModule, TypeIcon],
   templateUrl: './pokemon.component.html',
   styleUrl: './pokemon.component.scss',
 })
 export class PokemonComponent {
   private _pokemon!: PokemonVM;
+  readonly moveSlots = [0, 1, 2, 3];
 
   @Input() set pokemon(value: PokemonVM) {
     this._pokemon = {
       ...value,
       stats: value.stats ?? [],
+      moves: value.moves ?? [],
+      selectedMoves: Array.isArray(value.selectedMoves)
+        ? value.selectedMoves
+        : [null, null, null, null],
     };
   }
   get pokemon(): PokemonVM {
@@ -26,6 +37,7 @@ export class PokemonComponent {
 
   @Input() showRemove = true; // por si quieres ocultar el botón en otros contextos
   @Output() remove = new EventEmitter<number>();
+  @Output() moveChange = new EventEmitter<PokemonMoveSelectionPayload>();
 
   typeIcons = inject(TypeIconService);
 
@@ -33,8 +45,21 @@ export class PokemonComponent {
     this.remove.emit(this.pokemon.id);
   }
 
+  onMoveSelect(slot: number, moveUrl: string | null) {
+    const normalized = moveUrl?.trim() ? moveUrl : null;
+    this.moveChange.emit({
+      pokemonId: this.pokemon.id,
+      slot,
+      moveUrl: normalized,
+    });
+  }
+
   trackType(i: number, t: any) {
     return t?.name ?? i;
+  }
+
+  trackMove(_i: number, move: PokemonMoveOptionVM) {
+    return move?.url ?? _i;
   }
 
   icon$(url: string) {

--- a/src/app/team/ui/team-panel/team-panel.component.html
+++ b/src/app/team/ui/team-panel/team-panel.component.html
@@ -30,7 +30,11 @@
   @if (team.length) {
     <div class="team-grid">
       @for (p of team; track trackById($index, p)) {
-        <app-pokemon [pokemon]="p" (remove)="remove.emit($event)"></app-pokemon>
+        <app-pokemon
+          [pokemon]="p"
+          (remove)="remove.emit($event)"
+          (moveChange)="moveChange.emit($event)"
+        ></app-pokemon>
       }
     </div>
   } @else {

--- a/src/app/team/ui/team-panel/team-panel.component.ts
+++ b/src/app/team/ui/team-panel/team-panel.component.ts
@@ -1,6 +1,6 @@
 import { Component, EventEmitter, Input, Output } from '@angular/core';
 import { FormsModule } from '@angular/forms';
-import { PokemonVM } from '../../models/view.model';
+import { PokemonMoveSelectionPayload, PokemonVM } from '../../models/view.model';
 import { SavedTeam } from '../../models/team.model';
 import { PokemonComponent } from '../pokemon/pokemon.component';
 
@@ -21,6 +21,7 @@ export class TeamPanelComponent {
   @Output() teamNameChange = new EventEmitter<string>();
   @Output() selectTeam = new EventEmitter<string | null>();
   @Output() createTeam = new EventEmitter<void>();
+  @Output() moveChange = new EventEmitter<PokemonMoveSelectionPayload>();
 
   trackById(_i: number, p: PokemonVM) {
     return (p as any).id ?? p;


### PR DESCRIPTION
## Summary
- extend the Pokémon view model and mapper to expose available moves and normalized move details
- add facade and API support to load move data and persist four move selections per team member
- update team and card UIs with move selectors, detail display, and styling for the chosen attacks

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dce190e4e48326bf45f3fc198f6d73