### PR TITLE
feat: show move move details in dropdown

### DIFF
--- a/src/app/team/data/pokemon.mapper.ts
+++ b/src/app/team/data/pokemon.mapper.ts
@@ -29,6 +29,8 @@ export class PokemonMapper {
           name: move.move.name,
           label: this.formatMoveName(move.move.name),
           url: move.move.url,
+          type: null,
+          power: null,
         })) ?? [],
       selectedMoves: [],
     };
@@ -113,6 +115,8 @@ export class PokemonMapper {
         name: option.name,
         label: option.label ?? this.formatMoveName(option.name),
         url: option.url,
+        type: option.type && option.type.url ? { name: option.type.name, url: option.type.url } : null,
+        power: option.power ?? null,
       }));
   }
 

--- a/src/app/team/data/team.facade.ts
+++ b/src/app/team/data/team.facade.ts
@@ -321,7 +321,19 @@ export class TeamFacade {
       const nextTeam = [...current];
       const pokemon = this.mapper.normalizeVM(nextTeam[index]);
       const selectedMoves = [...pokemon.selectedMoves];
-      selectedMoves[slot] = this.mapper.normalizeMoveDetail(detail);
+      const normalizedDetail = this.mapper.normalizeMoveDetail(detail);
+      selectedMoves[slot] = normalizedDetail;
+      if (normalizedDetail?.url && (normalizedDetail.type || normalizedDetail.power !== null)) {
+        pokemon.moves = pokemon.moves.map((move) =>
+          move.url === normalizedDetail.url
+            ? {
+                ...move,
+                type: normalizedDetail.type,
+                power: normalizedDetail.power,
+              }
+            : move
+        );
+      }
       pokemon.selectedMoves = selectedMoves;
       nextTeam[index] = pokemon;
       this.syncDraftMembers(nextTeam);

--- a/src/app/team/models/view.model.ts
+++ b/src/app/team/models/view.model.ts
@@ -19,6 +19,8 @@ export interface PokemonMoveOptionVM {
   name: string;
   label: string;
   url: string;
+  type: { name: string; url: string } | null;
+  power: number | null;
 }
 
 export interface PokemonMoveDetailVM {

--- a/src/app/team/ui/pokemon/pokemon.component.html
+++ b/src/app/team/ui/pokemon/pokemon.component.html
@@ -44,10 +44,13 @@
       @let selected = pokemon.selectedMoves[slot];
       <li class="moves__item">
         <select class="moves__select" [id]="'move-' + pokemon.id + '-' + slot" [ngModel]="selected?.url ?? ''"
-          (ngModelChange)="onMoveSelect(slot, $event)">
-          <option value="">Movimiento {{ slot + 1 }}</option>
+          [ngStyle]="selectedOptionStyle(selected)" (ngModelChange)="onMoveSelect(slot, $event)">
+          <option class="moves__option moves__option--placeholder" value="">Movimiento {{ slot + 1 }}</option>
           @for (move of pokemon.moves; track trackMove($index, move)) {
-          <option [value]="move.url">{{ move.label }}</option>
+          <option class="moves__option" [ngClass]="{ 'moves__option--with-icon': move.type }"
+            [ngStyle]="typeIconStyle(move)" [value]="move.url">
+            {{ formatMoveOptionLabel(move) }}
+          </option>
           }
         </select>
         @if (selected) {

--- a/src/app/team/ui/pokemon/pokemon.component.scss
+++ b/src/app/team/ui/pokemon/pokemon.component.scss
@@ -163,12 +163,27 @@
     font-size: 0.9rem;
     color: #111827;
     transition: border-color 0.2s ease, box-shadow 0.2s ease;
+    background-repeat: no-repeat;
+    background-position: 0.6rem center;
+    background-size: 1.5rem 1.5rem;
+
+    option {
+      padding: 0.35rem 0.75rem;
+    }
 
     &:focus {
       outline: none;
       border-color: #6366f1;
       box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.15);
       background: #fff;
+    }
+  }
+
+  &__option {
+    &--with-icon {
+      background-repeat: no-repeat;
+      background-position: 0.6rem center;
+      background-size: 1.5rem 1.5rem;
     }
   }
 


### PR DESCRIPTION
## Summary
- include type and power metadata in move option view models and propagate fetched move details back into the options list
- enrich the Pokémon move selector so each option displays its icon and power directly inside the dropdown with updated styling

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dcf88e5e708326a5ca478aa1acfa1a