### PR TITLE
feat: improve move selection with ng-select

### DIFF
--- a/src/app/team/ui/pokemon/pokemon.component.html
+++ b/src/app/team/ui/pokemon/pokemon.component.html
@@ -43,16 +43,40 @@
       @for (slot of moveSlots; track slot) {
       @let selected = pokemon.selectedMoves[slot];
       <li class="moves__item">
-        <select class="moves__select" [id]="'move-' + pokemon.id + '-' + slot" [ngModel]="selected?.url ?? ''"
-          [ngStyle]="selectedOptionStyle(selected)" (ngModelChange)="onMoveSelect(slot, $event)">
-          <option class="moves__option moves__option--placeholder" value="">Movimiento {{ slot + 1 }}</option>
-          @for (move of pokemon.moves; track trackMove($index, move)) {
-          <option class="moves__option" [ngClass]="{ 'moves__option--with-icon': move.type }"
-            [ngStyle]="typeIconStyle(move)" [value]="move.url">
-            {{ formatMoveOptionLabel(move) }}
-          </option>
-          }
-        </select>
+        <ng-select class="moves__select" [items]="pokemon.moves" bindLabel="label" bindValue="url"
+          [id]="'move-' + pokemon.id + '-' + slot" [placeholder]="'Movimiento ' + (slot + 1)"
+          [clearable]="true" [ngModel]="selected?.url ?? null" (ngModelChange)="onMoveSelect(slot, $event)"
+          [searchable]="true" [virtualScroll]="true">
+          <ng-template ng-label-tmp let-item="item">
+            @let icon = getMoveIcon(item);
+            <div class="moves__option moves__option--selected">
+              @if (icon) {
+              <img class="moves__option-icon" [src]="icon" [alt]="item.type?.name ?? 'tipo'" />
+              } @else if (item.type?.name) {
+              <span class="moves__option-type moves__option-type--pill">{{ formatTypeName(item.type.name) }}</span>
+              }
+              <span class="moves__option-name">{{ item.label }}</span>
+            </div>
+          </ng-template>
+
+          <ng-template ng-option-tmp let-item="item">
+            @let icon = getMoveIcon(item);
+            <div class="moves__option">
+              @if (icon) {
+              <img class="moves__option-icon" [src]="icon" [alt]="item.type?.name ?? 'tipo'" />
+              } @else if (item.type?.name) {
+              <span class="moves__option-type moves__option-type--pill">{{ formatTypeName(item.type.name) }}</span>
+              }
+              <div class="moves__option-text">
+                <span class="moves__option-name">{{ item.label }}</span>
+                <span class="moves__option-meta" *ngIf="item.type?.name || item.power !== null">
+                  <span class="moves__option-type" *ngIf="item.type?.name">{{ formatTypeName(item.type.name) }}</span>
+                  <span class="moves__option-power" *ngIf="item.power !== null">Poder: {{ item.power }}</span>
+                </span>
+              </div>
+            </div>
+          </ng-template>
+        </ng-select>
         @if (selected) {
         <div class="moves__summary">
           @if (selected.type) {

--- a/src/app/team/ui/pokemon/pokemon.component.scss
+++ b/src/app/team/ui/pokemon/pokemon.component.scss
@@ -155,36 +155,94 @@
   }
 
   &__select {
-    appearance: none;
-    padding: 0.4rem 0.5rem;
-    border: 1px solid #d1d5db;
-    border-radius: 0.5rem;
-    background: #f9fafb;
-    font-size: 0.9rem;
-    color: #111827;
-    transition: border-color 0.2s ease, box-shadow 0.2s ease;
-    background-repeat: no-repeat;
-    background-position: 0.6rem center;
-    background-size: 1.5rem 1.5rem;
+    width: 100%;
 
-    option {
-      padding: 0.35rem 0.75rem;
+    ::ng-deep .ng-select-container {
+      min-height: 2.5rem;
+      border: 1px solid #d1d5db;
+      border-radius: 0.5rem;
+      background: #f9fafb;
+      font-size: 0.9rem;
+      color: #111827;
+      transition: border-color 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease;
+      padding: 0.25rem 0.5rem;
     }
 
-    &:focus {
-      outline: none;
+    ::ng-deep .ng-select-container:hover {
+      background: #fff;
+    }
+
+    ::ng-deep .ng-select-focused .ng-select-container {
       border-color: #6366f1;
       box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.15);
       background: #fff;
     }
+
+    ::ng-deep .ng-select-container .ng-value {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+    }
+
+    ::ng-deep .ng-select-container .ng-value-label {
+      margin: 0;
+    }
   }
 
   &__option {
-    &--with-icon {
-      background-repeat: no-repeat;
-      background-position: 0.6rem center;
-      background-size: 1.5rem 1.5rem;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+
+    &--selected {
+      gap: 0.4rem;
     }
+  }
+
+  &__option-icon {
+    width: 1.5rem;
+    height: 1.5rem;
+    object-fit: contain;
+  }
+
+  &__option-text {
+    display: flex;
+    flex-direction: column;
+    gap: 0.1rem;
+  }
+
+  &__option-name {
+    font-weight: 600;
+    color: #111827;
+  }
+
+  &__option-meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.35rem;
+    font-size: 0.75rem;
+    color: #4b5563;
+  }
+
+  &__option-type {
+    text-transform: capitalize;
+
+    &--pill {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      min-width: 1.5rem;
+      padding: 0.1rem 0.4rem;
+      border-radius: 9999px;
+      background: #e0e7ff;
+      font-size: 0.75rem;
+      font-weight: 600;
+      color: #4338ca;
+    }
+  }
+
+  &__option-power {
+    font-weight: 500;
   }
 
   &__summary {

--- a/src/app/team/ui/pokemon/pokemon.component.ts
+++ b/src/app/team/ui/pokemon/pokemon.component.ts
@@ -87,79 +87,15 @@ export class PokemonComponent {
     });
   }
 
-  trackType(i: number, t: any) {
-    return t?.name ?? i;
-  }
-
-  trackMove(_i: number, move: PokemonMoveOptionVM) {
-    return move?.url ?? _i;
-  }
-
-  icon$(url: string) {
-    return this.typeIcons.getIconByTypeUrl(url);
-  }
-
-  typeIconStyle(move: PokemonMoveOptionVM): Record<string, string> | null {
-    const iconUrl = this.moveIconUrls[move.url];
-    if (iconUrl) {
-      return {
-        'background-image': `url(${iconUrl})`,
-        'background-repeat': 'no-repeat',
-        'background-position': '0.6rem center',
-        'background-size': '1.5rem 1.5rem',
-        'padding-left': '2.8rem',
-      };
-    }
-
-    if (move.type) {
-      return {
-        'padding-left': '2.4rem',
-      };
-    }
-
-    return null;
-  }
-
-  selectedOptionStyle(selected: PokemonMoveDetailVM | null): Record<string, string> | null {
-    if (!selected) {
+  getMoveIcon(move: PokemonMoveOptionVM | PokemonMoveDetailVM | null): string | null {
+    if (!move) {
       return null;
     }
 
-    const iconUrl = selected.url ? this.moveIconUrls[selected.url] : null;
-    if (iconUrl) {
-      return {
-        'background-image': `url(${iconUrl})`,
-        'background-repeat': 'no-repeat',
-        'background-position': '0.6rem center',
-        'background-size': '1.5rem 1.5rem',
-        'padding-left': '2.8rem',
-      };
-    }
-
-    if (selected.type) {
-      return {
-        'padding-left': '2.4rem',
-      };
-    }
-
-    return null;
+    return this.moveIconUrls[move.url] ?? null;
   }
 
-  formatMoveOptionLabel(move: PokemonMoveOptionVM): string {
-    const parts = [move.label];
-
-    if (move.type?.name) {
-      parts.push(this.formatTypeName(move.type.name));
-    }
-
-    if (move.power !== null) {
-      parts.push(`Poder: ${move.power}`);
-    }
-
-    return parts.join(' - ');
-  }
-
-  private formatTypeName(value: string): string {
+  formatTypeName(value: string): string {
     return value
       .split(/[-\s]+/)
       .filter(Boolean)


### PR DESCRIPTION
## Summary
- replace the basic move selector with ng-select and custom option templates that show the move type icon, name, and power
- style the new ng-select dropdown to match the card layout and support type badges when no icon is available
- expose helpers in the component to resolve move icons and formatted type names for the templates

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dcfcff250c83268a405476faba07b7