### PR TITLE
feat: replace move selection with modal picker

### DIFF
--- a/src/app/team/data/pokemon.mapper.ts
+++ b/src/app/team/data/pokemon.mapper.ts
@@ -31,6 +31,9 @@ export class PokemonMapper {
           url: move.move.url,
           type: null,
           power: null,
+          accuracy: null,
+          damageClass: null,
+          effect: null,
         })) ?? [],
       selectedMoves: [],
     };
@@ -66,6 +69,9 @@ export class PokemonMapper {
       url,
       type: dto.type && dto.type.url ? { name: dto.type.name, url: dto.type.url } : null,
       power: dto.power ?? null,
+      accuracy: dto.accuracy ?? null,
+      damageClass: dto.damage_class?.name ?? null,
+      effect: this.formatEffectText(dto),
     };
   }
 
@@ -76,6 +82,9 @@ export class PokemonMapper {
       url,
       type: null,
       power: null,
+      accuracy: null,
+      damageClass: null,
+      effect: null,
     };
   }
 
@@ -91,6 +100,9 @@ export class PokemonMapper {
       url: detail.url,
       type,
       power: detail.power ?? null,
+      accuracy: detail.accuracy ?? null,
+      damageClass: detail.damageClass ?? null,
+      effect: detail.effect ?? null,
     };
   }
 
@@ -102,6 +114,34 @@ export class PokemonMapper {
     const normalized = (value ?? '').trim();
     if (!normalized) return 'Movimiento';
     return this.toTitleCase(normalized.replace(/-/g, ' '));
+  }
+
+  private formatEffectText(dto: MoveDTO): string | null {
+    const entries = dto.effect_entries ?? [];
+    if (!entries.length) {
+      return null;
+    }
+
+    const preferred =
+      entries.find((entry) => entry.language?.name === 'es') ??
+      entries.find((entry) => entry.language?.name === 'en') ??
+      entries[0];
+
+    if (!preferred) {
+      return null;
+    }
+
+    const base = preferred.short_effect || preferred.effect;
+    if (!base) {
+      return null;
+    }
+
+    const effectChance = dto.effect_chance ?? null;
+    const normalized = effectChance === null || effectChance === undefined
+      ? base
+      : base.replace(/\$effect_chance/g, String(effectChance));
+
+    return normalized.replace(/\s+/g, ' ').trim();
   }
 
   private normalizeMoveOptions(options: PokemonMoveOptionVM[] | undefined): PokemonMoveOptionVM[] {
@@ -117,6 +157,9 @@ export class PokemonMapper {
         url: option.url,
         type: option.type && option.type.url ? { name: option.type.name, url: option.type.url } : null,
         power: option.power ?? null,
+        accuracy: option.accuracy ?? null,
+        damageClass: option.damageClass ?? null,
+        effect: option.effect ?? null,
       }));
   }
 

--- a/src/app/team/data/team.facade.ts
+++ b/src/app/team/data/team.facade.ts
@@ -323,13 +323,16 @@ export class TeamFacade {
       const selectedMoves = [...pokemon.selectedMoves];
       const normalizedDetail = this.mapper.normalizeMoveDetail(detail);
       selectedMoves[slot] = normalizedDetail;
-      if (normalizedDetail?.url && (normalizedDetail.type || normalizedDetail.power !== null)) {
+      if (normalizedDetail?.url) {
         pokemon.moves = pokemon.moves.map((move) =>
           move.url === normalizedDetail.url
             ? {
                 ...move,
                 type: normalizedDetail.type,
                 power: normalizedDetail.power,
+                accuracy: normalizedDetail.accuracy,
+                damageClass: normalizedDetail.damageClass,
+                effect: normalizedDetail.effect,
               }
             : move
         );

--- a/src/app/team/models/pokeapi.dto.ts
+++ b/src/app/team/models/pokeapi.dto.ts
@@ -20,5 +20,13 @@ export interface MoveDTO {
   id: number;
   name: string;
   power: number | null;
+  accuracy: number | null;
+  damage_class: { name: string } | null;
   type: { name: string; url: string } | null;
+  effect_entries?: {
+    effect: string;
+    short_effect: string;
+    language: { name: string };
+  }[];
+  effect_chance?: number | null;
 }

--- a/src/app/team/models/view.model.ts
+++ b/src/app/team/models/view.model.ts
@@ -21,6 +21,9 @@ export interface PokemonMoveOptionVM {
   url: string;
   type: { name: string; url: string } | null;
   power: number | null;
+  accuracy: number | null;
+  damageClass: string | null;
+  effect: string | null;
 }
 
 export interface PokemonMoveDetailVM {
@@ -28,6 +31,9 @@ export interface PokemonMoveDetailVM {
   url: string;
   type: { name: string; url: string } | null;
   power: number | null;
+  accuracy: number | null;
+  damageClass: string | null;
+  effect: string | null;
 }
 
 export interface PokemonMoveSelectionPayload {

--- a/src/app/team/ui/pokemon/pokemon.component.html
+++ b/src/app/team/ui/pokemon/pokemon.component.html
@@ -38,27 +38,29 @@
 
   @if (pokemon.moves.length) {
   <section class="moves">
-    <h4 class="moves__title">Movimientos</h4>
-    <ul class="moves__list">
+    <div class="moves__header">
+      <h4 class="moves__title">Movimientos</h4>
+      <button type="button" class="moves__manage" (click)="openMoveModal()">Gestionar</button>
+    </div>
+    <ul class="moves__selected-list">
       @for (slot of moveSlots; track slot) {
       @let selected = pokemon.selectedMoves[slot];
-      <li class="moves__item">
-        <ng-select class="moves__select" [items]="pokemon.moves" bindLabel="label" bindValue="url"
-          [id]="'move-' + pokemon.id + '-' + slot" [placeholder]="'Movimiento ' + (slot + 1)" [clearable]="true"
-          [ngModel]="selected?.url ?? null" (ngModelChange)="onMoveSelect(slot, $event)" [searchable]="true"
-          [virtualScroll]="true">
-          <ng-template ng-label-tmp let-item="item">
-            @let icon = getMoveIcon(item);
-            <div class="moves__option moves__option--selected">
-              @if (icon) {
-              <img class="moves__option-icon" [src]="icon" [alt]="item.type?.name ?? 'tipo'" />
-              } @else if (item.type?.name) {
-              <span class="moves__option-type moves__option-type--pill">{{ formatTypeName(item.type.name) }}</span>
-              }
-              <span class="moves__option-name">{{ item.label }}</span>
-            </div>
-          </ng-template>
-        </ng-select>
+      <li class="moves__selected-item">
+        <button type="button" class="moves__selected-button" (click)="openMoveModal()">
+          @if (selected) {
+          <span class="moves__selected-content">
+            @let icon = getMoveIcon(selected);
+            @if (icon) {
+            <img class="moves__selected-icon" [src]="icon" [alt]="selected.type?.name ?? 'tipo'" />
+            } @else if (selected.type?.name) {
+            <span class="moves__selected-type">{{ formatTypeName(selected.type?.name ?? '') }}</span>
+            }
+            <span class="moves__selected-name">{{ selected.name }}</span>
+          </span>
+          } @else {
+          <span class="moves__placeholder">Seleccionar movimiento {{ slot + 1 }}</span>
+          }
+        </button>
       </li>
       }
     </ul>
@@ -71,3 +73,105 @@
     }
   </footer>
 </article>
+
+@if (isMoveModalOpen) {
+<div class="move-modal">
+  <div class="move-modal__backdrop" (click)="closeMoveModal()"></div>
+  <div class="move-modal__dialog" role="dialog" aria-modal="true" aria-label="Selector de movimientos">
+    <header class="move-modal__header">
+      <h3 class="move-modal__title">Selecciona los movimientos</h3>
+      <button type="button" class="move-modal__close" (click)="closeMoveModal()" aria-label="Cerrar">×</button>
+    </header>
+    <div class="move-modal__body">
+      <label class="move-modal__search">
+        <span class="move-modal__search-label">Buscar</span>
+        <input type="search" class="move-modal__search-input" [(ngModel)]="moveSearchTerm"
+          (ngModelChange)="onSearchTermChange()" placeholder="Buscar movimiento" />
+      </label>
+
+      <div class="move-modal__selected">
+        <div class="move-modal__selected-header">
+          <h4 class="move-modal__selected-title">Movimientos seleccionados</h4>
+          <span class="move-modal__selected-count">{{ pendingSelectionCount }}/4</span>
+        </div>
+        <ul class="move-modal__selected-list">
+          @for (slot of moveSlots; track slot) {
+          @let move = pendingSelection[slot];
+          <li class="move-modal__selected-item">
+            @if (move) {
+            <button type="button" class="move-modal__selected-chip" (click)="removeSelectedMove(slot)">
+              @let icon = getMoveIcon(move);
+              @if (icon) {
+              <img class="move-modal__selected-icon" [src]="icon" [alt]="move.type?.name ?? 'tipo'" />
+              } @else if (move.type?.name) {
+              <span class="move-modal__selected-type">{{ formatTypeName(move.type?.name ?? '') }}</span>
+              }
+              <span class="move-modal__selected-name">{{ move.name }}</span>
+              <span class="move-modal__selected-remove" aria-hidden="true">×</span>
+            </button>
+            } @else {
+            <span class="move-modal__selected-placeholder">Hueco libre</span>
+            }
+          </li>
+          }
+        </ul>
+      </div>
+
+      <div class="move-modal__table-wrapper">
+        <table class="move-modal__table">
+          <thead>
+            <tr>
+              <th scope="col">Movimiento</th>
+              <th scope="col">Tipo</th>
+              <th scope="col">Poder</th>
+              <th scope="col">Precisión</th>
+              <th scope="col">Categoría</th>
+              <th scope="col" class="move-modal__effect-column">Efecto</th>
+            </tr>
+          </thead>
+          <tbody>
+            @if (!filteredMoveRows.length) {
+            <tr class="move-modal__empty">
+              <td colspan="6">No hay movimientos que coincidan con la búsqueda.</td>
+            </tr>
+            } @else {
+            @for (row of filteredMoveRows; track row.url) {
+            <tr class="move-modal__row" (click)="toggleMoveSelection(row)"
+              [class.is-selected]="isMoveSelected(row.url)"
+              [class.is-disabled]="pendingSelectionCount >= moveSlots.length && !isMoveSelected(row.url)">
+              <td data-label="Movimiento">{{ row.label }}</td>
+              <td data-label="Tipo">
+                @if (row.typeIcon) {
+                <img class="move-modal__type-icon" [src]="row.typeIcon" [alt]="row.type?.name ?? 'tipo'" />
+                } @else if (row.type?.name) {
+                <span class="move-modal__type-pill">{{ formatTypeName(row.type?.name ?? '') }}</span>
+                } @else {
+                <span class="move-modal__type-pill">—</span>
+                }
+              </td>
+              <td data-label="Poder">{{ row.power !== null ? row.power : '—' }}</td>
+              <td data-label="Precisión">{{ row.accuracy !== null ? row.accuracy + '%' : '—' }}</td>
+              <td data-label="Categoría">{{ formatCategory(row.damageClass) }}</td>
+              <td data-label="Efecto" class="move-modal__effect-cell">
+                @if (row.effect) {
+                <span class="move-modal__effect" [title]="row.effect">{{ row.effect }}</span>
+                } @else if (row.loading) {
+                <span class="move-modal__effect move-modal__effect--loading">Cargando…</span>
+                } @else {
+                <span class="move-modal__effect">—</span>
+                }
+              </td>
+            </tr>
+            }
+            }
+          </tbody>
+        </table>
+      </div>
+    </div>
+    <footer class="move-modal__footer">
+      <button type="button" class="move-modal__cancel" (click)="closeMoveModal()">Cancelar</button>
+      <button type="button" class="move-modal__save" (click)="saveMoveSelection()">Guardar</button>
+    </footer>
+  </div>
+</div>
+}

--- a/src/app/team/ui/pokemon/pokemon.component.scss
+++ b/src/app/team/ui/pokemon/pokemon.component.scss
@@ -118,160 +118,90 @@
   }
 }
 ::ng-deep .ng-dropdown-panel {
-  background-color: white;
+  display: none;
 }
+
 .moves {
   display: flex;
-  flex-flow: column;
-  gap: 0.5rem;
+  flex-direction: column;
+  gap: 0.75rem;
+
+  &__header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+  }
 
   &__title {
     margin: 0;
     font-size: 0.875rem;
     font-weight: 600;
     text-transform: uppercase;
-    letter-spacing: 0.05em;
     color: #4b5563;
   }
 
-  &__list {
-    display: flex;
-    flex-flow: row wrap;
-    gap: 0.75rem;
-    justify-content: space-between;
+  &__manage {
+    border: 1px solid #6366f1;
+    background: #eef2ff;
+    color: #4338ca;
+    font-size: 0.75rem;
+    font-weight: 600;
+    padding: 0.25rem 0.6rem;
+    border-radius: 9999px;
+    cursor: pointer;
+  }
+
+  &__selected-list {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+    gap: 0.5rem;
     list-style: none;
     margin: 0;
     padding: 0;
   }
 
-  &__item {
-    display: flex;
-    flex-direction: column;
-    gap: 0.35rem;
-  }
-
-  &__label {
-    font-size: 0.85rem;
-    font-weight: 500;
-    color: #111827;
-  }
-
-  &__select {
+  &__selected-button {
     width: 100%;
-
-    ::ng-deep .ng-select-container {
-      min-height: 2.5rem;
-      border: 1px solid #d1d5db;
-      border-radius: 0.5rem;
-      background: #f9fafb;
-      font-size: 0.9rem;
-      color: #111827;
-      transition: border-color 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease;
-      padding: 0.25rem 0.5rem;
-    }
-
-    ::ng-deep .ng-select-container:hover {
-      background: #fff;
-    }
-
-    ::ng-deep .ng-select-focused .ng-select-container {
-      border-color: #6366f1;
-      box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.15);
-      background: #fff;
-    }
-
-    ::ng-deep .ng-select-container .ng-value {
-      display: flex;
-      align-items: center;
-      gap: 0.5rem;
-    }
-
-    ::ng-deep .ng-select-container .ng-value-label {
-      margin: 0;
-    }
-  }
-
-  &__option {
+    border: 1px solid #d1d5db;
+    border-radius: 0.75rem;
+    background: #f9fafb;
+    padding: 0.5rem 0.75rem;
     display: flex;
     align-items: center;
     gap: 0.5rem;
-    border-bottom: 1px solid #d1d3d6;
-    margin: 0.5rem 0;
-    &--selected {
-      gap: 0.4rem;
-    }
+    min-height: 3rem;
+    text-align: left;
+    cursor: pointer;
   }
 
-  &__option-icon {
-    width: 4.5rem;
-    height: 1.5rem;
+  &__selected-icon,
+  &__selected-type {
+    font-size: 0.75rem;
+    font-weight: 600;
+    text-transform: capitalize;
+  }
+
+  &__selected-icon {
+    width: 60px;
+    height: 18px;
     object-fit: contain;
   }
 
-  &__option-text {
-    display: flex;
-    flex-direction: column;
-    gap: 0.1rem;
+  &__selected-type {
+    color: #0369a1;
   }
 
-  &__option-name {
-    font-weight: 600;
+  &__selected-name {
+    font-size: 0.85rem;
     color: #111827;
   }
 
-  &__option-meta {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 0.35rem;
-    font-size: 0.75rem;
-    color: #4b5563;
-  }
-
-  &__option-type {
-    text-transform: capitalize;
-
-    &--pill {
-      display: inline-flex;
-      align-items: center;
-      justify-content: center;
-      min-width: 1.5rem;
-      padding: 0.1rem 0.4rem;
-      border-radius: 9999px;
-      background: #e0e7ff;
-      font-size: 0.75rem;
-      font-weight: 600;
-      color: #4338ca;
-    }
-  }
-
-  &__option-power {
-    font-weight: 500;
-  }
-
-  &__summary {
-    display: flex;
-    align-items: center;
-    flex-wrap: wrap;
-    gap: 0.5rem;
-    font-size: 0.85rem;
-    color: #374151;
-  }
-
-  &__name {
-    font-weight: 600;
-    text-transform: capitalize;
-  }
-
-  &__type {
-    display: flex;
-    align-items: center;
-  }
-
-  &__power {
-    font-variant-numeric: tabular-nums;
-    color: #1f2937;
+  &__placeholder {
+    font-size: 0.8rem;
+    color: #6b7280;
   }
 }
+
 
 /* Footer pegado abajo para acciones consistentes */
 .actions {

--- a/src/app/team/ui/pokemon/pokemon.component.ts
+++ b/src/app/team/ui/pokemon/pokemon.component.ts
@@ -1,8 +1,12 @@
 import { CommonModule } from '@angular/common';
 import { Component, EventEmitter, Input, Output, inject } from '@angular/core';
 import { FormsModule } from '@angular/forms';
+import { finalize, take } from 'rxjs/operators';
+
 import { TypeIcon } from '../../../shared/ui/type-icon/type-icon';
 import { STAT_MAX_VALUES } from '../../../shared/util/constants';
+import { PokemonApi } from '../../data/pokemon.api';
+import { PokemonMapper } from '../../data/pokemon.mapper';
 import { TypeIconService } from '../../data/type-icon.service';
 import {
   PokemonMoveDetailVM,
@@ -11,19 +15,43 @@ import {
   PokemonStatVM,
   PokemonVM,
 } from '../../models/view.model';
-import { take } from 'rxjs/operators';
-import { NgSelectModule } from '@ng-select/ng-select';
+
+type MoveTableRow = {
+  url: string;
+  label: string;
+  type: { name: string; url: string } | null;
+  typeIcon: string | null;
+  power: number | null;
+  accuracy: number | null;
+  damageClass: string | null;
+  effect: string | null;
+  loading: boolean;
+  searchIndex: string;
+};
 
 @Component({
   selector: 'app-pokemon',
-  imports: [CommonModule, FormsModule, TypeIcon, NgSelectModule],
+  imports: [CommonModule, FormsModule, TypeIcon],
   templateUrl: './pokemon.component.html',
   styleUrl: './pokemon.component.scss',
 })
 export class PokemonComponent {
   private _pokemon!: PokemonVM;
   readonly moveSlots = [0, 1, 2, 3];
+
   private moveIconUrls: Record<string, string | null> = {};
+  private moveDetailCache: Record<string, PokemonMoveDetailVM> = {};
+  private pendingDetailRequests = new Set<string>();
+
+  isMoveModalOpen = false;
+  moveSearchTerm = '';
+  moveTableRows: MoveTableRow[] = [];
+  filteredMoveRows: MoveTableRow[] = [];
+  pendingSelection: (PokemonMoveDetailVM | null)[] = [null, null, null, null];
+
+  private readonly typeIcons = inject(TypeIconService);
+  private readonly api = inject(PokemonApi);
+  private readonly mapper = inject(PokemonMapper);
 
   @Input() set pokemon(value: PokemonVM) {
     this._pokemon = {
@@ -34,48 +62,85 @@ export class PokemonComponent {
         ? value.selectedMoves
         : [null, null, null, null],
     };
+    this.pendingSelection = this._pokemon.selectedMoves.map((move) => (move ? { ...move } : null));
+    this.initializeMoveDetailCache();
     this.prepareMoveIcons();
+    if (this.isMoveModalOpen) {
+      this.initializeMoveTableRows();
+    }
   }
   get pokemon(): PokemonVM {
     return this._pokemon;
   }
 
-  @Input() showRemove = true; // por si quieres ocultar el botón en otros contextos
+  @Input() showRemove = true;
   @Output() remove = new EventEmitter<number>();
   @Output() moveChange = new EventEmitter<PokemonMoveSelectionPayload>();
 
-  typeIcons = inject(TypeIconService);
-
-  private prepareMoveIcons() {
-    const moves = this._pokemon?.moves ?? [];
-    const moveUrls = new Set(moves.map((move) => move.url));
-
-    for (const url of Object.keys(this.moveIconUrls)) {
-      if (!moveUrls.has(url)) {
-        delete this.moveIconUrls[url];
-      }
-    }
-
-    moves.forEach((move) => {
-      const typeUrl = move.type?.url;
-      if (!typeUrl || this.moveIconUrls[move.url] !== undefined) {
-        return;
-      }
-
-      this.typeIcons
-        .getIconByTypeUrl(typeUrl)
-        .pipe(take(1))
-        .subscribe((iconUrl) => {
-          this.moveIconUrls = {
-            ...this.moveIconUrls,
-            [move.url]: iconUrl,
-          };
-        });
-    });
-  }
-
   onRemove() {
     this.remove.emit(this.pokemon.id);
+  }
+
+  openMoveModal() {
+    this.pendingSelection = this.pokemon.selectedMoves.map((move) => (move ? { ...move } : null));
+    this.moveSearchTerm = '';
+    this.isMoveModalOpen = true;
+    this.initializeMoveTableRows();
+  }
+
+  closeMoveModal() {
+    this.isMoveModalOpen = false;
+    this.moveTableRows = [];
+    this.filteredMoveRows = [];
+  }
+
+  onSearchTermChange() {
+    this.refreshFilteredMoveRows();
+  }
+
+  toggleMoveSelection(row: MoveTableRow) {
+    if (this.isMoveSelected(row.url)) {
+      this.removeMoveFromPending(row.url);
+      return;
+    }
+
+    if (this.pendingSelectionCount >= this.moveSlots.length) {
+      return;
+    }
+
+    const detail = this.getMoveDetailForRow(row);
+    const emptyIndex = this.pendingSelection.findIndex((move) => move === null);
+    if (emptyIndex === -1) {
+      return;
+    }
+
+    this.pendingSelection = this.pendingSelection.map((move, index) =>
+      index === emptyIndex ? detail : move
+    );
+  }
+
+  removeSelectedMove(index: number) {
+    if (index < 0 || index >= this.pendingSelection.length) {
+      return;
+    }
+
+    this.pendingSelection = this.pendingSelection.map((move, current) =>
+      current === index ? null : move
+    );
+  }
+
+  saveMoveSelection() {
+    this.pendingSelection.forEach((move, index) => {
+      const previous = this.pokemon.selectedMoves[index];
+      const previousUrl = previous?.url ?? null;
+      const nextUrl = move?.url ?? null;
+
+      if (previousUrl !== nextUrl) {
+        this.onMoveSelect(index, nextUrl);
+      }
+    });
+
+    this.closeMoveModal();
   }
 
   onMoveSelect(slot: number, moveUrl: string | null) {
@@ -87,6 +152,14 @@ export class PokemonComponent {
     });
   }
 
+  get pendingSelectionCount(): number {
+    return this.pendingSelection.filter((move) => !!move).length;
+  }
+
+  isMoveSelected(url: string): boolean {
+    return this.pendingSelection.some((move) => move?.url === url);
+  }
+
   getMoveIcon(move: PokemonMoveOptionVM | PokemonMoveDetailVM | null): string | null {
     if (!move) {
       return null;
@@ -96,11 +169,15 @@ export class PokemonComponent {
   }
 
   formatTypeName(value: string): string {
-    return value
-      .split(/[-\s]+/)
-      .filter(Boolean)
-      .map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1))
-      .join(' ');
+    return this.toTitleCase(value);
+  }
+
+  formatCategory(value: string | null): string {
+    if (!value) {
+      return '—';
+    }
+
+    return this.toTitleCase(value);
   }
 
   getStatPercentage(stat: PokemonStatVM): number {
@@ -121,5 +198,261 @@ export class PokemonComponent {
     const endColor = `hsl(${hue}, 85%, 45%)`;
 
     return `linear-gradient(90deg, ${startColor} 0%, ${endColor} 100%)`;
+  }
+
+  private initializeMoveDetailCache() {
+    const selectedMoves = this._pokemon?.selectedMoves ?? [];
+    selectedMoves.forEach((move) => {
+      if (move?.url) {
+        this.moveDetailCache[move.url] = move;
+      }
+    });
+
+    const availableMoves = this._pokemon?.moves ?? [];
+    availableMoves.forEach((move) => {
+      if (!move?.url) {
+        return;
+      }
+
+      if (this.moveDetailCache[move.url]) {
+        return;
+      }
+
+      const detail = this.mapper.normalizeMoveDetail({
+        name: move.label,
+        url: move.url,
+        type: move.type,
+        power: move.power,
+        accuracy: move.accuracy,
+        damageClass: move.damageClass,
+        effect: move.effect,
+      });
+
+      if (detail) {
+        this.moveDetailCache[move.url] = detail;
+      }
+    });
+  }
+
+  private initializeMoveTableRows() {
+    const rows: MoveTableRow[] = (this.pokemon.moves ?? []).map((move) => ({
+      url: move.url,
+      label: move.label,
+      type: move.type,
+      typeIcon: this.moveIconUrls[move.url] ?? null,
+      power: move.power ?? null,
+      accuracy: move.accuracy ?? null,
+      damageClass: move.damageClass ?? null,
+      effect: move.effect ?? null,
+      loading: false,
+      searchIndex: this.buildSearchIndex(move.label, move.damageClass, move.effect),
+    }));
+
+    this.moveTableRows = rows;
+    rows.forEach((row) => this.ensureMoveIcon(row.type?.url ?? null, row.url));
+    this.refreshFilteredMoveRows();
+    this.prefetchMoveDetailsForRows(this.filteredMoveRows.slice(0, 20));
+  }
+
+  private refreshFilteredMoveRows() {
+    if (!this.isMoveModalOpen) {
+      this.filteredMoveRows = [];
+      return;
+    }
+
+    const term = this.moveSearchTerm.trim().toLowerCase();
+    if (!term) {
+      this.filteredMoveRows = [...this.moveTableRows];
+    } else {
+      this.filteredMoveRows = this.moveTableRows.filter((row) => row.searchIndex.includes(term));
+    }
+    this.prefetchMoveDetailsForRows(this.filteredMoveRows.slice(0, 20));
+  }
+
+  private prefetchMoveDetailsForRows(rows: MoveTableRow[]) {
+    if (!this.isMoveModalOpen) {
+      return;
+    }
+
+    rows.forEach((row) => this.ensureMoveDetail(row));
+  }
+
+  private ensureMoveDetail(row: MoveTableRow) {
+    if (this.moveDetailCache[row.url] || this.pendingDetailRequests.has(row.url)) {
+      return;
+    }
+
+    this.pendingDetailRequests.add(row.url);
+    this.updateMoveRow(row.url, { loading: true });
+
+    this.api
+      .getMoveByUrl(row.url)
+      .pipe(
+        take(1),
+        finalize(() => {
+          this.pendingDetailRequests.delete(row.url);
+          this.updateMoveRow(row.url, { loading: false });
+        })
+      )
+      .subscribe({
+        next: (dto) => {
+          const detail = this.mapper.moveDetailFromDto(dto, row.url);
+          this.moveDetailCache[row.url] = detail;
+          this.updateMoveRow(row.url, {
+            type: detail.type,
+            power: detail.power,
+            accuracy: detail.accuracy,
+            damageClass: detail.damageClass,
+            effect: detail.effect,
+            typeIcon: this.moveIconUrls[row.url] ?? null,
+          });
+          this.updateMoveOptionWithDetail(detail);
+          this.ensureMoveIcon(detail.type?.url ?? null, detail.url);
+        },
+        error: (error) => {
+          console.error('Error loading move details', error);
+        },
+      });
+  }
+
+  private updateMoveRow(url: string, changes: Partial<MoveTableRow>) {
+    if (!this.isMoveModalOpen) {
+      return;
+    }
+
+    const index = this.moveTableRows.findIndex((row) => row.url === url);
+    if (index === -1) {
+      return;
+    }
+
+    const current = this.moveTableRows[index];
+    const updated: MoveTableRow = {
+      ...current,
+      ...changes,
+      searchIndex: this.buildSearchIndex(
+        changes.label ?? current.label,
+        changes.damageClass ?? current.damageClass,
+        changes.effect ?? current.effect
+      ),
+    };
+
+    this.moveTableRows = [
+      ...this.moveTableRows.slice(0, index),
+      updated,
+      ...this.moveTableRows.slice(index + 1),
+    ];
+    this.refreshFilteredMoveRows();
+  }
+
+  private updateMoveOptionWithDetail(detail: PokemonMoveDetailVM) {
+    this._pokemon.moves = this._pokemon.moves.map((move) =>
+      move.url === detail.url
+        ? {
+            ...move,
+            type: detail.type,
+            power: detail.power,
+            accuracy: detail.accuracy,
+            damageClass: detail.damageClass,
+            effect: detail.effect,
+          }
+        : move
+    );
+    this.prepareMoveIcons();
+  }
+
+  private ensureMoveIcon(typeUrl: string | null, moveUrl: string) {
+    if (!typeUrl) {
+      return;
+    }
+
+    if (this.moveIconUrls[moveUrl] !== undefined) {
+      return;
+    }
+
+    this.typeIcons
+      .getIconByTypeUrl(typeUrl)
+      .pipe(take(1))
+      .subscribe((iconUrl) => {
+        this.moveIconUrls = {
+          ...this.moveIconUrls,
+          [moveUrl]: iconUrl,
+        };
+        this.updateMoveRow(moveUrl, { typeIcon: iconUrl });
+      });
+  }
+
+  private prepareMoveIcons() {
+    const moveSources: (PokemonMoveOptionVM | PokemonMoveDetailVM)[] = [
+      ...(this._pokemon?.moves ?? []),
+      ...((this._pokemon?.selectedMoves ?? []).filter(
+        (move): move is PokemonMoveDetailVM => !!move
+      ) ?? []),
+    ];
+
+    const moveUrls = new Set(moveSources.map((move) => move.url));
+    Object.keys(this.moveIconUrls).forEach((url) => {
+      if (!moveUrls.has(url)) {
+        delete this.moveIconUrls[url];
+      }
+    });
+
+    moveSources.forEach((move) => {
+      this.ensureMoveIcon(move.type?.url ?? null, move.url);
+    });
+  }
+
+  private buildSearchIndex(
+    label: string | null | undefined,
+    damageClass: string | null,
+    effect: string | null
+  ): string {
+    return [label ?? '', damageClass ?? '', effect ?? '']
+      .join(' ')
+      .toLowerCase();
+  }
+
+  private removeMoveFromPending(url: string) {
+    const index = this.pendingSelection.findIndex((move) => move?.url === url);
+    if (index === -1) {
+      return;
+    }
+
+    this.removeSelectedMove(index);
+  }
+
+  private getMoveDetailForRow(row: MoveTableRow): PokemonMoveDetailVM {
+    const cached = this.moveDetailCache[row.url];
+    if (cached) {
+      return cached;
+    }
+
+    this.ensureMoveDetail(row);
+    const normalized =
+      this.mapper.normalizeMoveDetail({
+        name: row.label,
+        url: row.url,
+        type: row.type,
+        power: row.power,
+        accuracy: row.accuracy,
+        damageClass: row.damageClass,
+        effect: row.effect,
+      });
+
+    if (normalized) {
+      this.moveDetailCache[row.url] = normalized;
+      return normalized;
+    }
+
+    const placeholder = this.mapper.createMovePlaceholder(undefined, row.url);
+    this.moveDetailCache[row.url] = placeholder;
+    return placeholder;
+  }
+
+  private toTitleCase(value: string): string {
+    return value
+      .split(/[-\s]+/)
+      .filter(Boolean)
+      .map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1))
+      .join(' ');
   }
 }

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -34,3 +34,244 @@ h1, h2, h3, .heading {
 
 /* Accesibilidad: asegura contraste en chips de tipo si usas color */
 .type-icon img { filter: drop-shadow(0 1px 0 rgba(0,0,0,.08)); }
+
+.move-modal {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+
+  &__backdrop {
+    position: absolute;
+    inset: 0;
+    background: rgba(15, 23, 42, 0.55);
+  }
+
+  &__dialog {
+    position: relative;
+    z-index: 1;
+    width: min(960px, 100%);
+    max-height: 90vh;
+    display: flex;
+    flex-direction: column;
+    background: #ffffff;
+    border-radius: 1rem;
+    overflow: hidden;
+    box-shadow: 0 18px 35px rgba(15, 23, 42, 0.18);
+  }
+
+  &__header,
+  &__footer {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+    padding: 1rem 1.25rem;
+    border-bottom: 1px solid #e5e7eb;
+  }
+
+  &__footer {
+    border-bottom: 0;
+    border-top: 1px solid #e5e7eb;
+    justify-content: flex-end;
+  }
+
+  &__title {
+    margin: 0;
+    font-size: 1rem;
+    font-weight: 700;
+    color: #111827;
+  }
+
+  &__close {
+    border: 0;
+    background: transparent;
+    font-size: 1.5rem;
+    line-height: 1;
+    cursor: pointer;
+    color: #6b7280;
+  }
+
+  &__body {
+    padding: 1rem 1.25rem;
+    overflow: auto;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+  }
+
+  &__search {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+  }
+
+  &__search-label {
+    font-size: 0.75rem;
+    font-weight: 600;
+    color: #4b5563;
+    text-transform: uppercase;
+  }
+
+  &__search-input {
+    padding: 0.45rem 0.75rem;
+    border-radius: 0.75rem;
+    border: 1px solid #cbd5f5;
+    font-size: 0.9rem;
+  }
+
+  &__selected {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+
+  &__selected-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    font-size: 0.8rem;
+    font-weight: 600;
+  }
+
+  &__selected-list {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    gap: 0.5rem;
+    list-style: none;
+    margin: 0;
+    padding: 0;
+  }
+
+  &__selected-item,
+  &__selected-placeholder {
+    border: 1px solid #e5e7eb;
+    border-radius: 9999px;
+    min-height: 2.5rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.35rem 0.75rem;
+    font-size: 0.75rem;
+  }
+
+  &__selected-chip {
+    width: 100%;
+    border: 0;
+    background: #eef2ff;
+    border-radius: 9999px;
+    padding: 0.35rem 0.75rem;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    font-size: 0.75rem;
+    font-weight: 600;
+    color: #312e81;
+    cursor: pointer;
+  }
+
+  &__selected-icon {
+    width: 48px;
+    height: 18px;
+    object-fit: contain;
+  }
+
+  &__table-wrapper {
+    border: 1px solid #e5e7eb;
+    border-radius: 0.75rem;
+    overflow: hidden;
+  }
+
+  &__table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.85rem;
+
+    thead {
+      background: #f1f5f9;
+    }
+
+    th,
+    td {
+      padding: 0.6rem 0.75rem;
+      border-bottom: 1px solid #e2e8f0;
+      vertical-align: top;
+    }
+
+    th {
+      font-weight: 600;
+      text-align: left;
+      font-size: 0.7rem;
+      text-transform: uppercase;
+    }
+  }
+
+  &__row {
+    cursor: pointer;
+
+    &.is-selected {
+      background: #e0e7ff;
+    }
+
+    &.is-disabled {
+      opacity: 0.55;
+      cursor: not-allowed;
+    }
+  }
+
+  &__type-icon {
+    width: 60px;
+    height: 18px;
+    object-fit: contain;
+  }
+
+  &__type-pill {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.15rem 0.5rem;
+    border-radius: 9999px;
+    background: #f3f4f6;
+    font-size: 0.75rem;
+  }
+
+  &__effect {
+    display: -webkit-box;
+    -webkit-line-clamp: 3;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+  }
+
+  &__effect--loading {
+    font-style: italic;
+  }
+
+  &__empty td {
+    text-align: center;
+    padding: 1.25rem 0.75rem;
+    color: #6b7280;
+  }
+
+  &__cancel,
+  &__save {
+    border-radius: 0.75rem;
+    font-weight: 600;
+    padding: 0.45rem 1.1rem;
+    cursor: pointer;
+    border: 1px solid transparent;
+  }
+
+  &__cancel {
+    border-color: #e5e7eb;
+    background: #ffffff;
+  }
+
+  &__save {
+    border-color: #4f46e5;
+    background: #4f46e5;
+    color: #ffffff;
+  }
+}


### PR DESCRIPTION
## Summary
- replace the move select dropdown with a modal picker that supports search, inline stats and enforcing four-move limits
- enrich move view models and mapper logic with accuracy, damage class and effect text to populate the modal table
- store move styling in global styles and update the pokemon card to show the chosen moves with their type icons

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e6341dfb8483268fc2977247f6c516