### PR TITLE
feat: replace move selector with search modal

### DIFF
--- a/src/app/team/data/pokemon.mapper.ts
+++ b/src/app/team/data/pokemon.mapper.ts
@@ -31,6 +31,9 @@ export class PokemonMapper {
           url: move.move.url,
           type: null,
           power: null,
+          accuracy: null,
+          category: null,
+          effect: null,
         })) ?? [],
       selectedMoves: [],
     };
@@ -61,11 +64,20 @@ export class PokemonMapper {
   }
 
   moveDetailFromDto(dto: MoveDTO, url: string): PokemonMoveDetailVM {
+    const type = dto.type && dto.type.url ? { name: dto.type.name, url: dto.type.url } : null;
+    const category = dto.damage_class?.name
+      ? this.toTitleCase(dto.damage_class.name.replace(/-/g, ' '))
+      : null;
+    const effect = this.extractEffectText(dto.effect_entries, dto.effect_chance);
+
     return {
       name: this.formatMoveName(dto.name),
       url,
-      type: dto.type && dto.type.url ? { name: dto.type.name, url: dto.type.url } : null,
+      type,
       power: dto.power ?? null,
+      accuracy: dto.accuracy ?? null,
+      category,
+      effect,
     };
   }
 
@@ -76,6 +88,9 @@ export class PokemonMapper {
       url,
       type: null,
       power: null,
+      accuracy: null,
+      category: null,
+      effect: null,
     };
   }
 
@@ -85,13 +100,54 @@ export class PokemonMapper {
     }
 
     const type = detail.type && detail.type.url ? { name: detail.type.name, url: detail.type.url } : null;
+    const category = detail.category ? this.toTitleCase(detail.category.replace(/-/g, ' ')) : null;
+    const effect = this.normalizeEffect(detail.effect);
 
     return {
       name: this.formatMoveName(detail.name ?? this.extractNameFromUrl(detail.url)),
       url: detail.url,
       type,
       power: detail.power ?? null,
+      accuracy: detail.accuracy ?? null,
+      category,
+      effect,
     };
+  }
+
+  private extractEffectText(
+    entries: MoveDTO['effect_entries'] | undefined,
+    chance: number | null
+  ): string | null {
+    if (!Array.isArray(entries) || !entries.length) {
+      return null;
+    }
+
+    const preferred =
+      entries.find((entry) => entry.language?.name === 'es') ??
+      entries.find((entry) => entry.language?.name === 'en');
+
+    const raw = preferred?.short_effect ?? preferred?.effect ?? '';
+    if (!raw.trim()) {
+      return null;
+    }
+
+    const normalizedChance = typeof chance === 'number' ? String(chance) : '';
+    const withChance = raw.replace(/\$effect_chance/gi, normalizedChance);
+
+    return this.normalizeEffect(withChance);
+  }
+
+  private normalizeEffect(effect: string | null | undefined): string | null {
+    if (!effect) {
+      return null;
+    }
+
+    const normalized = effect
+      .replace(/[\u000b\u000c]/g, ' ')
+      .replace(/\s+/g, ' ')
+      .trim();
+
+    return normalized.length ? normalized : null;
   }
 
   private toTitleCase(value: string): string {
@@ -117,6 +173,9 @@ export class PokemonMapper {
         url: option.url,
         type: option.type && option.type.url ? { name: option.type.name, url: option.type.url } : null,
         power: option.power ?? null,
+        accuracy: option.accuracy ?? null,
+        category: option.category ? this.toTitleCase(option.category.replace(/-/g, ' ')) : null,
+        effect: this.normalizeEffect(option.effect),
       }));
   }
 

--- a/src/app/team/data/team.facade.ts
+++ b/src/app/team/data/team.facade.ts
@@ -323,13 +323,16 @@ export class TeamFacade {
       const selectedMoves = [...pokemon.selectedMoves];
       const normalizedDetail = this.mapper.normalizeMoveDetail(detail);
       selectedMoves[slot] = normalizedDetail;
-      if (normalizedDetail?.url && (normalizedDetail.type || normalizedDetail.power !== null)) {
+      if (normalizedDetail?.url) {
         pokemon.moves = pokemon.moves.map((move) =>
           move.url === normalizedDetail.url
             ? {
                 ...move,
                 type: normalizedDetail.type,
                 power: normalizedDetail.power,
+                accuracy: normalizedDetail.accuracy,
+                category: normalizedDetail.category,
+                effect: normalizedDetail.effect,
               }
             : move
         );

--- a/src/app/team/models/pokeapi.dto.ts
+++ b/src/app/team/models/pokeapi.dto.ts
@@ -20,5 +20,9 @@ export interface MoveDTO {
   id: number;
   name: string;
   power: number | null;
+  accuracy: number | null;
+  effect_chance: number | null;
+  damage_class: { name: string } | null;
   type: { name: string; url: string } | null;
+  effect_entries: { effect: string; short_effect: string; language: { name: string } }[];
 }

--- a/src/app/team/models/view.model.ts
+++ b/src/app/team/models/view.model.ts
@@ -21,6 +21,9 @@ export interface PokemonMoveOptionVM {
   url: string;
   type: { name: string; url: string } | null;
   power: number | null;
+  accuracy: number | null;
+  category: string | null;
+  effect: string | null;
 }
 
 export interface PokemonMoveDetailVM {
@@ -28,6 +31,9 @@ export interface PokemonMoveDetailVM {
   url: string;
   type: { name: string; url: string } | null;
   power: number | null;
+  accuracy: number | null;
+  category: string | null;
+  effect: string | null;
 }
 
 export interface PokemonMoveSelectionPayload {

--- a/src/app/team/ui/pokemon/pokemon.component.html
+++ b/src/app/team/ui/pokemon/pokemon.component.html
@@ -38,31 +38,133 @@
 
   @if (pokemon.moves.length) {
   <section class="moves">
-    <h4 class="moves__title">Movimientos</h4>
-    <ul class="moves__list">
+    <div class="moves__header">
+      <h4 class="moves__title">Movimientos</h4>
+      <button type="button" class="moves__edit-button" (click)="openMovesModal()">Editar movimientos</button>
+    </div>
+
+    @if (hasSelectedMoves) {
+    <ul class="moves__selected-list">
       @for (slot of moveSlots; track slot) {
-      @let selected = pokemon.selectedMoves[slot];
-      <li class="moves__item">
-        <ng-select class="moves__select" [items]="pokemon.moves" bindLabel="label" bindValue="url"
-          [id]="'move-' + pokemon.id + '-' + slot" [placeholder]="'Movimiento ' + (slot + 1)" [clearable]="true"
-          [ngModel]="selected?.url ?? null" (ngModelChange)="onMoveSelect(slot, $event)" [searchable]="true"
-          [virtualScroll]="true">
-          <ng-template ng-label-tmp let-item="item">
-            @let icon = getMoveIcon(item);
-            <div class="moves__option moves__option--selected">
-              @if (icon) {
-              <img class="moves__option-icon" [src]="icon" [alt]="item.type?.name ?? 'tipo'" />
-              } @else if (item.type?.name) {
-              <span class="moves__option-type moves__option-type--pill">{{ formatTypeName(item.type.name) }}</span>
-              }
-              <span class="moves__option-name">{{ item.label }}</span>
-            </div>
-          </ng-template>
-        </ng-select>
+      @let move = pokemon.selectedMoves[slot];
+      @if (move) {
+      <li class="moves__selected-item">
+        @if (getMoveIcon(move); as icon) {
+        <img class="moves__selected-icon" [src]="icon" [alt]="move.type?.name ?? 'tipo'" />
+        } @else if (move.type?.name) {
+        <span class="moves__selected-type">{{ formatTypeName(move.type?.name ?? '') }}</span>
+        }
+        <span class="moves__selected-name">{{ move.name }}</span>
       </li>
       }
+      }
     </ul>
+    } @else {
+    <p class="moves__empty">No hay movimientos seleccionados. Pulsa en «Editar movimientos» para elegir hasta
+      cuatro.</p>
+    }
   </section>
+  }
+
+  @if (isMoveModalOpen) {
+  <div class="moves-modal" role="dialog" aria-modal="true" [attr.aria-labelledby]="'moves-modal-title-' + pokemon.id">
+    <div class="moves-modal__backdrop" (click)="closeMovesModal()"></div>
+    <div class="moves-modal__dialog" role="document">
+      <header class="moves-modal__header">
+        <h5 class="moves-modal__title" [id]="'moves-modal-title-' + pokemon.id">Selecciona movimientos</h5>
+        <button type="button" class="moves-modal__close" (click)="closeMovesModal()" aria-label="Cerrar">×</button>
+      </header>
+
+      <div class="moves-modal__content">
+        <div class="moves-modal__search">
+          <label class="moves-modal__search-label" [attr.for]="'move-search-' + pokemon.id">Buscar movimiento</label>
+          <input class="moves-modal__search-input" type="text" [id]="'move-search-' + pokemon.id"
+            [ngModel]="moveSearchTerm" (ngModelChange)="onSearchTermChange($event)"
+            placeholder="Empieza a escribir el nombre" />
+        </div>
+
+        <div class="moves-modal__selected">
+          <h6 class="moves-modal__selected-title">Seleccionados ({{ pendingSelectedMovesCount }}/4)</h6>
+          <ul class="moves-modal__selected-list">
+            @for (slot of moveSlots; track slot) {
+            @let pending = pendingSelectedMoves[slot];
+            <li class="moves-modal__selected-item" [class.is-filled]="!!pending">
+              <div class="moves-modal__slot">
+                <span class="moves-modal__slot-label">Movimiento {{ slot + 1 }}</span>
+                @if (pending) {
+                <div class="moves-modal__slot-move">
+                  @if (getMoveIcon(pending); as icon) {
+                  <img class="moves-modal__slot-icon" [src]="icon" [alt]="pending.type?.name ?? 'tipo'" />
+                  } @else if (pending.type?.name) {
+                  <span class="moves-modal__slot-type">{{ formatTypeName(pending.type?.name ?? '') }}</span>
+                  }
+                  <span class="moves-modal__slot-name">{{ pending.name }}</span>
+                </div>
+                } @else {
+                <span class="moves-modal__slot-empty">Vacío</span>
+                }
+              </div>
+              @if (pending) {
+              <button type="button" class="moves-modal__remove"
+                (click)="removePendingMove(slot); $event.stopPropagation()">Quitar</button>
+              }
+            </li>
+            }
+          </ul>
+        </div>
+
+        <div class="moves-modal__table-wrapper">
+          <table class="moves-modal__table">
+            <thead>
+              <tr>
+                <th>Nombre</th>
+                <th>Tipo</th>
+                <th>Poder</th>
+                <th>Precisión</th>
+                <th>Categoría</th>
+                <th>Efecto</th>
+              </tr>
+            </thead>
+            <tbody>
+              @for (move of filteredMoves; track move.url) {
+              <tr (click)="onMoveRowClick(move)" [class.is-selected]="isMoveSelected(move)"
+                [class.is-disabled]="!isMoveSelected(move) && !canSelectMoreMoves()">
+                <td class="moves-modal__cell-name">{{ move.label }}</td>
+                <td class="moves-modal__cell-type">
+                  @if (getMoveIcon(move); as icon) {
+                  <img class="moves-modal__table-icon" [src]="icon" [alt]="move.type?.name ?? 'tipo'" />
+                  } @else if (move.type?.name) {
+                  <span class="moves-modal__table-type">{{ formatTypeName(move.type?.name ?? '') }}</span>
+                  } @else {
+                  <span class="moves-modal__table-type moves-modal__table-type--unknown">—</span>
+                  }
+                </td>
+                <td class="moves-modal__cell-number">{{ move.power ?? '—' }}</td>
+                <td class="moves-modal__cell-number">{{ move.accuracy !== null ? move.accuracy + '%' : '—' }}</td>
+                <td>{{ move.category ?? '—' }}</td>
+                <td class="moves-modal__effect">{{ move.effect ?? '—' }}</td>
+              </tr>
+              }
+              @if (!filteredMoves.length) {
+              <tr>
+                <td class="moves-modal__empty" colspan="6">No se han encontrado movimientos que coincidan.</td>
+              </tr>
+              }
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      <footer class="moves-modal__footer">
+        <button type="button" class="moves-modal__button moves-modal__button--ghost" (click)="closeMovesModal()">
+          Cancelar
+        </button>
+        <button type="button" class="moves-modal__button" (click)="confirmMovesSelection()">
+          Guardar movimientos
+        </button>
+      </footer>
+    </div>
+  </div>
   }
 
   <footer class="actions">

--- a/src/app/team/ui/pokemon/pokemon.component.scss
+++ b/src/app/team/ui/pokemon/pokemon.component.scss
@@ -117,13 +117,17 @@
     font-weight: 600;
   }
 }
-::ng-deep .ng-dropdown-panel {
-  background-color: white;
-}
 .moves {
   display: flex;
-  flex-flow: column;
-  gap: 0.5rem;
+  flex-direction: column;
+  gap: 0.75rem;
+
+  &__header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+  }
 
   &__title {
     margin: 0;
@@ -134,142 +138,77 @@
     color: #4b5563;
   }
 
-  &__list {
-    display: flex;
-    flex-flow: row wrap;
-    gap: 0.75rem;
-    justify-content: space-between;
+  &__edit-button {
+    appearance: none;
+    border: 0;
+    border-radius: 9999px;
+    padding: 0.4rem 0.9rem;
+    font-size: 0.85rem;
+    font-weight: 600;
+    color: #f9fafb;
+    background: #6366f1;
+    cursor: pointer;
+    transition: background-color 0.15s ease;
+
+    &:hover {
+      background: #4f46e5;
+    }
+  }
+
+  &__selected-list {
     list-style: none;
     margin: 0;
     padding: 0;
-  }
-
-  &__item {
     display: flex;
     flex-direction: column;
-    gap: 0.35rem;
+    gap: 0.5rem;
   }
 
-  &__label {
-    font-size: 0.85rem;
-    font-weight: 500;
-    color: #111827;
-  }
-
-  &__select {
-    width: 100%;
-
-    ::ng-deep .ng-select-container {
-      min-height: 2.5rem;
-      border: 1px solid #d1d5db;
-      border-radius: 0.5rem;
-      background: #f9fafb;
-      font-size: 0.9rem;
-      color: #111827;
-      transition: border-color 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease;
-      padding: 0.25rem 0.5rem;
-    }
-
-    ::ng-deep .ng-select-container:hover {
-      background: #fff;
-    }
-
-    ::ng-deep .ng-select-focused .ng-select-container {
-      border-color: #6366f1;
-      box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.15);
-      background: #fff;
-    }
-
-    ::ng-deep .ng-select-container .ng-value {
-      display: flex;
-      align-items: center;
-      gap: 0.5rem;
-    }
-
-    ::ng-deep .ng-select-container .ng-value-label {
-      margin: 0;
-    }
-  }
-
-  &__option {
+  &__selected-item {
     display: flex;
     align-items: center;
-    gap: 0.5rem;
-    border-bottom: 1px solid #d1d3d6;
-    margin: 0.5rem 0;
-    &--selected {
-      gap: 0.4rem;
-    }
+    gap: 0.65rem;
+    padding: 0.45rem 0.75rem;
+    border-radius: 0.65rem;
+    border: 1px solid #e5e7eb;
+    background: #f9fafb;
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
   }
 
-  &__option-icon {
+  &__selected-icon {
     width: 4.5rem;
     height: 1.5rem;
     object-fit: contain;
   }
 
-  &__option-text {
-    display: flex;
-    flex-direction: column;
-    gap: 0.1rem;
+  &__selected-type {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.1rem 0.5rem;
+    border-radius: 9999px;
+    background: #e0e7ff;
+    color: #4338ca;
+    font-size: 0.75rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
   }
 
-  &__option-name {
+  &__selected-name {
     font-weight: 600;
     color: #111827;
+    font-size: 0.95rem;
   }
 
-  &__option-meta {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 0.35rem;
-    font-size: 0.75rem;
-    color: #4b5563;
-  }
-
-  &__option-type {
-    text-transform: capitalize;
-
-    &--pill {
-      display: inline-flex;
-      align-items: center;
-      justify-content: center;
-      min-width: 1.5rem;
-      padding: 0.1rem 0.4rem;
-      border-radius: 9999px;
-      background: #e0e7ff;
-      font-size: 0.75rem;
-      font-weight: 600;
-      color: #4338ca;
-    }
-  }
-
-  &__option-power {
-    font-weight: 500;
-  }
-
-  &__summary {
-    display: flex;
-    align-items: center;
-    flex-wrap: wrap;
-    gap: 0.5rem;
+  &__empty {
+    margin: 0;
     font-size: 0.85rem;
-    color: #374151;
-  }
-
-  &__name {
-    font-weight: 600;
-    text-transform: capitalize;
-  }
-
-  &__type {
-    display: flex;
-    align-items: center;
-  }
-
-  &__power {
-    font-variant-numeric: tabular-nums;
-    color: #1f2937;
+    color: #6b7280;
+    background: #f9fafb;
+    border-radius: 0.65rem;
+    padding: 0.75rem;
+    border: 1px dashed #cbd5f5;
   }
 }
 
@@ -291,6 +230,336 @@
 
     &:hover {
       background: #fecaca;
+    }
+  }
+}
+
+.moves-modal {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1.5rem;
+
+  &__backdrop {
+    position: absolute;
+    inset: 0;
+    background: rgba(15, 23, 42, 0.45);
+    backdrop-filter: blur(2px);
+  }
+
+  &__dialog {
+    position: relative;
+    width: min(960px, 100%);
+    max-height: min(90vh, 720px);
+    background: #fff;
+    border-radius: 0.85rem;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+  }
+
+  &__header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+    padding: 1.1rem 1.5rem;
+    border-bottom: 1px solid #e5e7eb;
+    background: #f8fafc;
+  }
+
+  &__title {
+    margin: 0;
+    font-size: 1.05rem;
+    font-weight: 700;
+    color: #1f2937;
+  }
+
+  &__close {
+    appearance: none;
+    border: 0;
+    background: transparent;
+    font-size: 1.5rem;
+    line-height: 1;
+    color: #6b7280;
+    cursor: pointer;
+  }
+
+  &__content {
+    display: flex;
+    flex-direction: column;
+    gap: 1.25rem;
+    padding: 1.25rem 1.5rem 1.5rem;
+  }
+
+  &__search {
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+  }
+
+  &__search-label {
+    font-size: 0.8rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: #4b5563;
+  }
+
+  &__search-input {
+    border: 1px solid #d1d5db;
+    border-radius: 0.65rem;
+    padding: 0.55rem 0.75rem;
+    font-size: 0.95rem;
+    &:focus {
+      outline: none;
+      border-color: #6366f1;
+      box-shadow: 0 0 0 2px rgba(99, 102, 241, 0.2);
+    }
+  }
+
+  &__selected {
+    display: flex;
+    flex-direction: column;
+    gap: 0.6rem;
+  }
+
+  &__selected-title {
+    margin: 0;
+    font-size: 0.9rem;
+    font-weight: 700;
+    color: #374151;
+  }
+
+  &__selected-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: grid;
+    gap: 0.6rem;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  }
+
+  &__selected-item {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.5rem;
+    border: 1px solid #d1d5db;
+    border-radius: 0.75rem;
+    padding: 0.55rem 0.75rem;
+  }
+
+  &__slot {
+    display: flex;
+    flex-direction: column;
+    gap: 0.3rem;
+  }
+
+  &__slot-label {
+    font-size: 0.75rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: #6b7280;
+  }
+
+  &__slot-move {
+    display: flex;
+    align-items: center;
+    gap: 0.45rem;
+  }
+
+  &__slot-icon {
+    width: 4.25rem;
+    height: 1.4rem;
+    object-fit: contain;
+  }
+
+  &__slot-type {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.1rem 0.5rem;
+    border-radius: 9999px;
+    background: #eef2ff;
+    color: #4338ca;
+    font-size: 0.7rem;
+    font-weight: 600;
+    text-transform: uppercase;
+  }
+
+  &__slot-name {
+    font-weight: 600;
+    color: #111827;
+    font-size: 0.95rem;
+  }
+
+  &__slot-empty {
+    font-size: 0.85rem;
+    color: #9ca3af;
+  }
+
+  &__remove {
+    appearance: none;
+    border: 0;
+    border-radius: 9999px;
+    padding: 0.25rem 0.6rem;
+    font-size: 0.75rem;
+    font-weight: 600;
+    background: #fee2e2;
+    color: #b91c1c;
+    cursor: pointer;
+    &:hover {
+      background: #fecaca;
+    }
+  }
+
+  &__table-wrapper {
+    flex: 1;
+    min-height: 0;
+    border: 1px solid #e5e7eb;
+    border-radius: 0.75rem;
+    overflow: hidden;
+  }
+
+  &__table {
+    width: 100%;
+    border-collapse: collapse;
+    background: #fff;
+
+    thead {
+      background: #f1f5f9;
+      position: sticky;
+      top: 0;
+      z-index: 1;
+    }
+
+    th {
+      text-align: left;
+      font-size: 0.75rem;
+      letter-spacing: 0.05em;
+      text-transform: uppercase;
+      color: #475569;
+      padding: 0.75rem;
+      border-bottom: 1px solid #e5e7eb;
+    }
+
+    td {
+      padding: 0.75rem;
+      font-size: 0.9rem;
+      border-bottom: 1px solid #f1f5f9;
+      vertical-align: top;
+      color: #1f2937;
+    }
+
+    tr {
+      &.is-selected {
+        background: rgba(99, 102, 241, 0.12);
+      }
+
+      &.is-disabled {
+        opacity: 0.6;
+      }
+    }
+  }
+
+  &__cell-name {
+    font-weight: 600;
+  }
+
+  &__cell-type,
+  &__cell-number {
+    font-variant-numeric: tabular-nums;
+  }
+
+  &__table-icon {
+    width: 4rem;
+    height: 1.35rem;
+    object-fit: contain;
+  }
+
+  &__table-type {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.1rem 0.45rem;
+    border-radius: 9999px;
+    background: #e0e7ff;
+    color: #4338ca;
+    font-size: 0.7rem;
+    font-weight: 600;
+    text-transform: uppercase;
+
+    &--unknown {
+      background: #e5e7eb;
+      color: #6b7280;
+    }
+  }
+
+  &__effect {
+    color: #4b5563;
+    font-size: 0.85rem;
+    line-height: 1.4;
+  }
+
+  &__empty {
+    text-align: center;
+    padding: 1.5rem;
+    color: #6b7280;
+    font-size: 0.9rem;
+  }
+
+  &__footer {
+    display: flex;
+    justify-content: flex-end;
+    gap: 0.75rem;
+    padding: 1rem 1.5rem;
+    border-top: 1px solid #e5e7eb;
+    background: #f8fafc;
+  }
+
+  &__button {
+    appearance: none;
+    border: 0;
+    border-radius: 0.65rem;
+    padding: 0.55rem 1.25rem;
+    font-size: 0.9rem;
+    font-weight: 600;
+    cursor: pointer;
+
+    &--ghost {
+      background: #e5e7eb;
+      color: #1f2937;
+    }
+
+    &:not(&--ghost) {
+      background: #6366f1;
+      color: #f9fafb;
+    }
+  }
+
+  @media (max-width: 720px) {
+    padding: 1rem;
+
+    &__dialog {
+      max-height: 92vh;
+    }
+
+    &__content {
+      padding: 1rem;
+    }
+
+    &__selected-list {
+      grid-template-columns: 1fr;
+    }
+
+    &__table td,
+    &__table th {
+      padding: 0.6rem;
     }
   }
 }

--- a/src/app/team/ui/pokemon/pokemon.component.ts
+++ b/src/app/team/ui/pokemon/pokemon.component.ts
@@ -3,6 +3,8 @@ import { Component, EventEmitter, Input, Output, inject } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { TypeIcon } from '../../../shared/ui/type-icon/type-icon';
 import { STAT_MAX_VALUES } from '../../../shared/util/constants';
+import { PokemonApi } from '../../data/pokemon.api';
+import { PokemonMapper } from '../../data/pokemon.mapper';
 import { TypeIconService } from '../../data/type-icon.service';
 import {
   PokemonMoveDetailVM,
@@ -11,12 +13,11 @@ import {
   PokemonStatVM,
   PokemonVM,
 } from '../../models/view.model';
-import { take } from 'rxjs/operators';
-import { NgSelectModule } from '@ng-select/ng-select';
+import { finalize, take } from 'rxjs/operators';
 
 @Component({
   selector: 'app-pokemon',
-  imports: [CommonModule, FormsModule, TypeIcon, NgSelectModule],
+  imports: [CommonModule, FormsModule, TypeIcon],
   templateUrl: './pokemon.component.html',
   styleUrl: './pokemon.component.scss',
 })
@@ -24,67 +25,147 @@ export class PokemonComponent {
   private _pokemon!: PokemonVM;
   readonly moveSlots = [0, 1, 2, 3];
   private moveIconUrls: Record<string, string | null> = {};
+  moveOptions: PokemonMoveOptionVM[] = [];
+  filteredMoves: PokemonMoveOptionVM[] = [];
+  pendingSelectedMoves: (PokemonMoveDetailVM | null)[] = [null, null, null, null];
+  moveSearchTerm = '';
+  isMoveModalOpen = false;
+  private readonly detailLoading = new Set<string>();
+  private readonly detailLoaded = new Set<string>();
+
+  private api = inject(PokemonApi);
+  private mapper = inject(PokemonMapper);
+  typeIcons = inject(TypeIconService);
 
   @Input() set pokemon(value: PokemonVM) {
+    const normalizedMoves = Array.isArray(value.moves)
+      ? value.moves.map((move) => ({ ...move }))
+      : [];
+    const baseSelected = Array.isArray(value.selectedMoves) ? value.selectedMoves : [];
+    const normalizedSelected = Array.from({ length: this.moveSlots.length }, (_, index) => {
+      const detail = baseSelected[index] ?? null;
+      return detail ? { ...detail } : null;
+    });
+
     this._pokemon = {
       ...value,
       stats: value.stats ?? [],
-      moves: value.moves ?? [],
-      selectedMoves: Array.isArray(value.selectedMoves)
-        ? value.selectedMoves
-        : [null, null, null, null],
+      moves: normalizedMoves,
+      selectedMoves: normalizedSelected,
     };
+
+    this.moveOptions = normalizedMoves.map((move) => ({ ...move }));
+    this.pendingSelectedMoves = normalizedSelected.map((move) => (move ? { ...move } : null));
+    this.moveIconUrls = {};
+    this.detailLoading.clear();
+    this.detailLoaded.clear();
+    this.moveOptions.forEach((move) => {
+      if (
+        move.type ||
+        move.power !== null ||
+        move.accuracy !== null ||
+        move.category ||
+        (move.effect && move.effect.trim())
+      ) {
+        this.detailLoaded.add(move.url);
+      }
+    });
+    this._pokemon.selectedMoves.forEach((move) => {
+      if (move?.url) {
+        this.detailLoaded.add(move.url);
+      }
+    });
     this.prepareMoveIcons();
+    this.updateFilteredMoves();
   }
   get pokemon(): PokemonVM {
     return this._pokemon;
   }
 
-  @Input() showRemove = true; // por si quieres ocultar el botón en otros contextos
+  @Input() showRemove = true;
   @Output() remove = new EventEmitter<number>();
   @Output() moveChange = new EventEmitter<PokemonMoveSelectionPayload>();
 
-  typeIcons = inject(TypeIconService);
+  openMovesModal() {
+    this.isMoveModalOpen = true;
+    this.moveSearchTerm = '';
+    this.resetPendingSelection();
+    this.updateFilteredMoves();
+    this.ensureDetailsForPendingSelection();
+  }
 
-  private prepareMoveIcons() {
-    const moves = this._pokemon?.moves ?? [];
-    const moveUrls = new Set(moves.map((move) => move.url));
+  closeMovesModal() {
+    this.isMoveModalOpen = false;
+    this.resetPendingSelection();
+    this.moveSearchTerm = '';
+    this.updateFilteredMoves();
+  }
 
-    for (const url of Object.keys(this.moveIconUrls)) {
-      if (!moveUrls.has(url)) {
-        delete this.moveIconUrls[url];
+  confirmMovesSelection() {
+    this.moveSlots.forEach((slot) => {
+      const current = this.pokemon.selectedMoves[slot];
+      const next = this.pendingSelectedMoves[slot];
+      const currentUrl = current?.url ?? null;
+      const nextUrl = next?.url ?? null;
+
+      if (currentUrl !== nextUrl) {
+        this.emitMoveChange(slot, nextUrl);
       }
+    });
+
+    this.closeMovesModal();
+  }
+
+  onSearchTermChange(term: string) {
+    this.moveSearchTerm = term ?? '';
+    this.updateFilteredMoves();
+  }
+
+  get hasSelectedMoves(): boolean {
+    return this.pokemon.selectedMoves.some((move) => !!move);
+  }
+
+  get pendingSelectedMovesCount(): number {
+    return this.pendingSelectedMoves.filter((move) => !!move).length;
+  }
+
+  canSelectMoreMoves(): boolean {
+    return this.pendingSelectedMovesCount < this.moveSlots.length;
+  }
+
+  isMoveSelected(move: PokemonMoveOptionVM): boolean {
+    return this.pendingSelectedMoves.some((selected) => selected?.url === move.url);
+  }
+
+  onMoveRowClick(move: PokemonMoveOptionVM) {
+    if (this.isMoveSelected(move)) {
+      this.removeMoveByUrl(move.url);
+      return;
     }
 
-    moves.forEach((move) => {
-      const typeUrl = move.type?.url;
-      if (!typeUrl || this.moveIconUrls[move.url] !== undefined) {
-        return;
-      }
+    if (!this.canSelectMoreMoves()) {
+      return;
+    }
 
-      this.typeIcons
-        .getIconByTypeUrl(typeUrl)
-        .pipe(take(1))
-        .subscribe((iconUrl) => {
-          this.moveIconUrls = {
-            ...this.moveIconUrls,
-            [move.url]: iconUrl,
-          };
-        });
-    });
+    this.addMoveToPending(move);
+  }
+
+  removePendingMove(slot: number) {
+    if (slot < 0 || slot >= this.pendingSelectedMoves.length) {
+      return;
+    }
+
+    if (!this.pendingSelectedMoves[slot]) {
+      return;
+    }
+
+    const next = [...this.pendingSelectedMoves];
+    next[slot] = null;
+    this.pendingSelectedMoves = next;
   }
 
   onRemove() {
     this.remove.emit(this.pokemon.id);
-  }
-
-  onMoveSelect(slot: number, moveUrl: string | null) {
-    const normalized = moveUrl?.trim() ? moveUrl : null;
-    this.moveChange.emit({
-      pokemonId: this.pokemon.id,
-      slot,
-      moveUrl: normalized,
-    });
   }
 
   getMoveIcon(move: PokemonMoveOptionVM | PokemonMoveDetailVM | null): string | null {
@@ -121,5 +202,223 @@ export class PokemonComponent {
     const endColor = `hsl(${hue}, 85%, 45%)`;
 
     return `linear-gradient(90deg, ${startColor} 0%, ${endColor} 100%)`;
+  }
+
+  private emitMoveChange(slot: number, moveUrl: string | null) {
+    const normalized = moveUrl?.trim() ? moveUrl : null;
+
+    this.moveChange.emit({
+      pokemonId: this.pokemon.id,
+      slot,
+      moveUrl: normalized,
+    });
+  }
+
+  private resetPendingSelection() {
+    this.pendingSelectedMoves = this._pokemon.selectedMoves.map((move) =>
+      move ? { ...move } : null
+    );
+  }
+
+  private addMoveToPending(move: PokemonMoveOptionVM) {
+    const index = this.pendingSelectedMoves.findIndex((item) => item === null);
+    if (index === -1) {
+      return;
+    }
+
+    const detail = this.toMoveDetail(move);
+    const next = [...this.pendingSelectedMoves];
+    next[index] = detail;
+    this.pendingSelectedMoves = next;
+  }
+
+  private removeMoveByUrl(url: string) {
+    let changed = false;
+    const next = this.pendingSelectedMoves.map((selected) => {
+      if (selected?.url === url) {
+        changed = true;
+        return null;
+      }
+      return selected;
+    });
+
+    if (changed) {
+      this.pendingSelectedMoves = next;
+    }
+  }
+
+  private toMoveDetail(move: PokemonMoveOptionVM): PokemonMoveDetailVM {
+    return {
+      name: move.label ?? move.name,
+      url: move.url,
+      type: move.type ?? null,
+      power: move.power ?? null,
+      accuracy: move.accuracy ?? null,
+      category: move.category ?? null,
+      effect: move.effect ?? null,
+    };
+  }
+
+  private updateFilteredMoves() {
+    const term = this.moveSearchTerm.trim().toLowerCase();
+    const base = [...this.moveOptions].sort((a, b) => a.label.localeCompare(b.label));
+    const filtered =
+      term.length === 0
+        ? base
+        : base.filter((move) => {
+            const label = move.label.toLowerCase();
+            const raw = move.name.toLowerCase();
+            return label.includes(term) || raw.includes(term);
+          });
+
+    this.filteredMoves = filtered;
+
+    this.filteredMoves.forEach((move) => {
+      if (!this.detailLoaded.has(move.url)) {
+        this.ensureMoveDetail(move.url);
+      }
+    });
+  }
+
+  private ensureMoveDetail(url: string) {
+    if (!url || this.detailLoaded.has(url) || this.detailLoading.has(url)) {
+      return;
+    }
+
+    const exists = this.moveOptions.some((move) => move.url === url);
+    if (!exists) {
+      return;
+    }
+
+    this.detailLoading.add(url);
+
+    this.api
+      .getMoveByUrl(url)
+      .pipe(
+        take(1),
+        finalize(() => {
+          this.detailLoading.delete(url);
+        })
+      )
+      .subscribe({
+        next: (dto) => {
+          const detail = this.mapper.moveDetailFromDto(dto, url);
+          const normalized = this.mapper.normalizeMoveDetail(detail);
+          if (normalized) {
+            this.detailLoaded.add(normalized.url);
+            this.applyMoveDetail(normalized);
+          }
+        },
+        error: (error) => {
+          console.error('Error al cargar el movimiento', error);
+        },
+      });
+  }
+
+  private applyMoveDetail(detail: PokemonMoveDetailVM) {
+    let updated = false;
+    const nextOptions = this.moveOptions.map((option) => {
+      if (option.url !== detail.url) {
+        return option;
+      }
+
+      updated = true;
+      return {
+        ...option,
+        name: detail.name ?? option.name,
+        label: detail.name ?? option.label,
+        type: detail.type ?? option.type,
+        power: detail.power ?? option.power,
+        accuracy: detail.accuracy ?? option.accuracy ?? null,
+        category: detail.category ?? option.category ?? null,
+        effect: detail.effect ?? option.effect ?? null,
+      };
+    });
+
+    if (!updated) {
+      return;
+    }
+
+    const nextSelected = this._pokemon.selectedMoves.map((selected) =>
+      selected?.url === detail.url
+        ? {
+            ...selected,
+            name: detail.name ?? selected.name,
+            type: detail.type ?? selected.type,
+            power: detail.power ?? selected.power,
+            accuracy: detail.accuracy ?? selected.accuracy,
+            category: detail.category ?? selected.category,
+            effect: detail.effect ?? selected.effect,
+          }
+        : selected
+    );
+
+    this.moveOptions = nextOptions;
+    this._pokemon = {
+      ...this._pokemon,
+      moves: nextOptions.map((option) => ({ ...option })),
+      selectedMoves: nextSelected,
+    };
+
+    this.pendingSelectedMoves = this.pendingSelectedMoves.map((selected) =>
+      selected?.url === detail.url
+        ? {
+            ...selected,
+            name: detail.name ?? selected.name,
+            type: detail.type ?? selected.type,
+            power: detail.power ?? selected.power,
+            accuracy: detail.accuracy ?? selected.accuracy,
+            category: detail.category ?? selected.category,
+            effect: detail.effect ?? selected.effect,
+          }
+        : selected
+    );
+
+    this.prepareMoveIcons();
+
+    if (this.isMoveModalOpen) {
+      this.updateFilteredMoves();
+    }
+  }
+
+  private ensureDetailsForPendingSelection() {
+    this.pendingSelectedMoves.forEach((move) => {
+      if (move?.url) {
+        this.ensureMoveDetail(move.url);
+      }
+    });
+  }
+
+  private prepareMoveIcons() {
+    const optionMoves = this.moveOptions ?? [];
+    const selectedMoves = (this._pokemon?.selectedMoves ?? []).filter(
+      (move): move is PokemonMoveDetailVM => !!move
+    );
+
+    const moves: (PokemonMoveOptionVM | PokemonMoveDetailVM)[] = [...optionMoves, ...selectedMoves];
+    const moveUrls = new Set(moves.map((move) => move.url));
+
+    Object.keys(this.moveIconUrls).forEach((url) => {
+      if (!moveUrls.has(url)) {
+        delete this.moveIconUrls[url];
+      }
+    });
+
+    moves.forEach((move) => {
+      const typeUrl = move.type?.url;
+      if (!typeUrl || this.moveIconUrls[move.url] !== undefined) {
+        return;
+      }
+
+      this.typeIcons
+        .getIconByTypeUrl(typeUrl)
+        .pipe(take(1))
+        .subscribe((iconUrl) => {
+          this.moveIconUrls = {
+            ...this.moveIconUrls,
+            [move.url]: iconUrl,
+          };
+        });
+    });
   }
 }


### PR DESCRIPTION
## Summary
- replace the move dropdown with a modal that lets you search and pick up to four moves, showing their type, power, accuracy, category and effect
- show the selected moves with their type icon on each Pokémon card and style the new interaction flow
- enrich move models, mapping and team updates so accuracy, category and effect data are preserved when loading move details

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e6341dfb8483268fc2977247f6c516