### PR TITLE
Improve search modal sorting and results

### DIFF
--- a/src/app/team/data/team.facade.ts
+++ b/src/app/team/data/team.facade.ts
@@ -286,7 +286,7 @@ export class TeamFacade {
       return;
     }
 
-    const batch = names.slice(offset, offset + 20);
+    const batch = names.slice(offset);
     this.isFetchingMore.set(true);
     this.loading.set(true);
 

--- a/src/app/team/ui/modals/search-modal/search-modal.component.html
+++ b/src/app/team/ui/modals/search-modal/search-modal.component.html
@@ -151,16 +151,46 @@
       <table class="results-table">
         <thead>
           <tr>
-            <th>Pokémon</th>
-            <th>Types</th>
-            <th>Abilities</th>
-            <th>Base stats</th>
+            <th>
+              <button type="button" class="sort-button" (click)="setSort('name')">
+                Pokémon
+                <span class="sort-indicator" *ngIf="sort.key === 'name'">
+                  {{ sort.direction === 'asc' ? '↑' : '↓' }}
+                </span>
+              </button>
+            </th>
+            <th>
+              <button type="button" class="sort-button" (click)="setSort('types')">
+                Types
+                <span class="sort-indicator" *ngIf="sort.key === 'types'">
+                  {{ sort.direction === 'asc' ? '↑' : '↓' }}
+                </span>
+              </button>
+            </th>
+            <th>
+              <button type="button" class="sort-button" (click)="setSort('abilities')">
+                Abilities
+                <span class="sort-indicator" *ngIf="sort.key === 'abilities'">
+                  {{ sort.direction === 'asc' ? '↑' : '↓' }}
+                </span>
+              </button>
+            </th>
+            @for (stat of statColumns; track stat.key) {
+            <th>
+              <button type="button" class="sort-button" (click)="setSort(stat.key)">
+                {{ stat.label }}
+                <span class="sort-indicator" *ngIf="sort.key === stat.key">
+                  {{ sort.direction === 'asc' ? '↑' : '↓' }}
+                </span>
+              </button>
+            </th>
+            }
             <th></th>
           </tr>
         </thead>
         <tbody>
-          @if (results.length) {
-          @for (pokemon of results; track trackById($index, pokemon)) {
+          @if (sortedResults.length) {
+          @for (pokemon of sortedResults; track trackById($index, pokemon)) {
           <tr>
             <td>
               <div class="pokemon-cell">
@@ -183,16 +213,9 @@
                 }
               </div>
             </td>
-            <td>
-              <div class="stats-grid">
-                @for (stat of pokemon.stats; track stat.name) {
-                <div class="stat">
-                  <span class="stat__label">{{ stat.label }}</span>
-                  <span class="stat__value">{{ stat.baseValue }}</span>
-                </div>
-                }
-              </div>
-            </td>
+            @for (stat of statColumns; track stat.key) {
+            <td class="stat-cell">{{ getStatBaseValue(pokemon, stat.key) }}</td>
+            }
             <td class="actions">
               <button type="button" class="modal__button modal__button--primary" (click)="add.emit(pokemon)">
                 Add
@@ -202,7 +225,7 @@
           }
           } @else {
           <tr>
-            <td colspan="5" class="empty">
+            <td [attr.colspan]="statColumns.length + 4" class="empty">
               @if (loading) {
               <span>Preparing results...</span>
               } @else {

--- a/src/app/team/ui/modals/search-modal/search-modal.component.scss
+++ b/src/app/team/ui/modals/search-modal/search-modal.component.scss
@@ -190,28 +190,10 @@
   gap: 0.35rem;
 }
 
-.stats-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(90px, 1fr));
-  gap: 0.35rem;
-}
-
-.stat {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: 0.35rem 0.45rem;
-  border-radius: 0.5rem;
-  background: #f9fafb;
-  border: 1px solid #e5e7eb;
-
-  &__label {
-    font-weight: 700;
-  }
-
-  &__value {
-    color: #1f2937;
-  }
+.stat-cell {
+  text-align: center;
+  font-weight: 700;
+  white-space: nowrap;
 }
 
 .actions {
@@ -226,6 +208,23 @@
 
 .footer-spacer {
   flex: 1;
+}
+
+.sort-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  background: none;
+  border: none;
+  padding: 0;
+  font: inherit;
+  color: inherit;
+  cursor: pointer;
+}
+
+.sort-indicator {
+  font-size: 0.85rem;
+  color: #6b7280;
 }
 
 @media (max-width: 900px) {

--- a/src/app/team/ui/modals/search-modal/search-modal.component.ts
+++ b/src/app/team/ui/modals/search-modal/search-modal.component.ts
@@ -2,8 +2,22 @@ import { CommonModule } from '@angular/common';
 import { Component, EventEmitter, Input, Output } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { TypeIcon } from '../../../../shared/ui/type-icon/type-icon';
+import { STAT_LABELS } from '../../../../shared/util/constants';
 import { SearchFilters } from '../../../models/search-filters.model';
 import { PokemonVM } from '../../../models/view.model';
+
+const STAT_COLUMN_KEYS = [
+  'hp',
+  'attack',
+  'defense',
+  'special-attack',
+  'special-defense',
+  'speed',
+] as const;
+
+type SortDirection = 'asc' | 'desc';
+type StatKey = (typeof STAT_COLUMN_KEYS)[number];
+type SortableColumn = 'name' | 'types' | 'abilities' | StatKey;
 
 @Component({
   standalone: true,
@@ -31,8 +45,21 @@ export class SearchModalComponent {
   abilityInput = '';
   moveInput = '';
 
+  readonly statColumns = STAT_COLUMN_KEYS.map((key) => ({ key, label: STAT_LABELS[key] }));
+
+  sort: { key: SortableColumn; direction: SortDirection } = { key: 'name', direction: 'asc' };
+
+  get sortedResults(): PokemonVM[] {
+    return [...this.results].sort((a, b) => this.comparePokemon(a, b));
+  }
+
   trackById(_index: number, pokemon: PokemonVM) {
     return pokemon.id;
+  }
+
+  setSort(key: SortableColumn) {
+    const direction = this.sort.key === key && this.sort.direction === 'asc' ? 'desc' : 'asc';
+    this.sort = { key, direction };
   }
 
   onNameChange(value: string) {
@@ -89,5 +116,36 @@ export class SearchModalComponent {
 
   private emitFilters(filters: SearchFilters) {
     this.filtersChange.emit(filters);
+  }
+
+  private comparePokemon(a: PokemonVM, b: PokemonVM): number {
+    const { key, direction } = this.sort;
+
+    let result = 0;
+
+    if (key === 'name') {
+      result = a.name.localeCompare(b.name);
+    } else if (key === 'types') {
+      result = this.getTypeLabel(a).localeCompare(this.getTypeLabel(b));
+    } else if (key === 'abilities') {
+      result = this.getAbilitiesLabel(a).localeCompare(this.getAbilitiesLabel(b));
+    } else {
+      result = this.getStatBaseValue(a, key) - this.getStatBaseValue(b, key);
+    }
+
+    return direction === 'asc' ? result : -result;
+  }
+
+  private getTypeLabel(pokemon: PokemonVM): string {
+    const types = pokemon.typeDetails?.map((type) => type.name) ?? pokemon.types ?? [];
+    return types.join(', ');
+  }
+
+  private getAbilitiesLabel(pokemon: PokemonVM): string {
+    return pokemon.abilityOptions.map((ability) => ability.label).join(', ');
+  }
+
+  getStatBaseValue(pokemon: PokemonVM, statName: StatKey): number {
+    return pokemon.stats.find((stat) => stat.name === statName)?.baseValue ?? 0;
   }
 }


### PR DESCRIPTION
## Summary
- show each base stat in its own sortable column within the search modal
- add client-side sorting controls for all result columns
- fetch full filtered result sets instead of limiting to 20 entries

## Testing
- npm run build


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694016616f5883268e9b56efd2d1fa7e)